### PR TITLE
fix(#24): use relative URL for WHEP connection resource

### DIFF
--- a/src/routes/whep_handler.rs
+++ b/src/routes/whep_handler.rs
@@ -41,8 +41,7 @@ pub async fn subscribe(
         .await
         .context("Failed to receive a whip offer")?;
 
-    let whep_port = app_state.get_port();
-    let url = format!("http://localhost:{}/channel/{}", whep_port, connection_id);
+    let url = format!("/channel/{}", connection_id);
     tracing::info!("Receiving streaming from: {}", url);
 
     Ok(HttpResponse::Created()

--- a/src/routes/whip_handler.rs
+++ b/src/routes/whip_handler.rs
@@ -29,8 +29,7 @@ pub async fn whip_request(
         .await
         .context("Failed to receive a whep offer")?;
 
-    let whep_port = app_state.get_port();
-    let url = format!("http://localhost:{}/channel/{}", whep_port, connection_id);
+    let url = format!("/channel/{}", connection_id);
     tracing::info!("Start streaming at: {}", url);
 
     Ok(HttpResponse::Ok()


### PR DESCRIPTION
This partially fixes #24 and does not cover the base URL option support