### PR TITLE
Fix: reduce latency

### DIFF
--- a/scripts/gst-commands
+++ b/scripts/gst-commands
@@ -37,7 +37,7 @@ gst-launch-1.0 srtsrc uri="srt://127.0.0.1:1234?mode=caller" ! queue ! decodebin
 gst-launch-1.0 -v \
     videotestsrc ! clockoverlay ! video/x-raw, height=360, width=640 ! videoconvert ! x264enc tune=zerolatency ! video/x-h264, profile=constrained-baseline ! mux. \
     audiotestsrc ! audio/x-raw, format=S16LE, channels=2, rate=44100 ! audioconvert ! voaacenc ! aacparse ! mux. \
-    mpegtsmux name=mux ! queue ! srtsink uri="srt://127.0.0.1:1234?mode=caller" wait-for-connection=false
+    mpegtsmux name=mux ! queue ! srtsink uri="srt://127.0.0.1:1234?mode=caller" wait-for-connection=false latency=5000
 
 gst-launch-1.0 -v \
     audiotestsrc ! audio/x-raw, format=S16LE, channels=2, rate=44100 ! audioconvert ! voaacenc ! aacparse ! mux. \

--- a/src/stream/gst_pipeline.rs
+++ b/src/stream/gst_pipeline.rs
@@ -221,6 +221,7 @@ impl PipelineBase for SharablePipeline {
 
         let src = gst::ElementFactory::make("srtsrc")
             .property("uri", uri)
+            .property("latency", 0)
             .build()?;
         let input_tee = gst::ElementFactory::make("tee").name("input_tee").build()?;
 
@@ -228,7 +229,10 @@ impl PipelineBase for SharablePipeline {
         let typefind = gst::ElementFactory::make("typefind")
             .name("typefind")
             .build()?;
-        let tsdemux = gst::ElementFactory::make("tsdemux").name("demux").build()?;
+        let tsdemux = gst::ElementFactory::make("tsdemux")
+            .name("demux")
+            .property("latency", 0)
+            .build()?;
 
         let video_queue = Self::create_custom_queue("video-queue", "0", "0", "no")?;
         let audio_queue = Self::create_custom_queue("audio-queue", "0", "0", "no")?;


### PR DESCRIPTION
It turned out that elements like `srtsrc`, `srtsink` and `tsdemux` have a default latency of 125, 125, and 700 ms respectively. To minimize the overall latency, we now set them to 0 instead.