### PR TITLE
Fix: reset pipeline on missing SDPs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::signal;
 use tokio::task;
-use tokio::time::{sleep, Duration};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -39,8 +38,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 tracing::info!("Pipeline reaches EOS. Reset and rerun the pipeline.");
             }
-
-            sleep(Duration::from_secs(1)).await;
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::signal;
 use tokio::task;
+use tokio::time::{sleep, Duration};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -27,9 +28,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let should_stop_clone = should_stop.clone();
     let appstate_clone = appstate.clone();
     let pipeline_clone = pipeline.clone();
+
     // Run the pipeline in a separate thread
     let pipeline_thread = task::spawn(async move {
+        let mut loops = 0;
         while !should_stop_clone.load(Ordering::Relaxed) {
+            tracing::debug!("Looping pipeline: {}", loops);
+            loops += 1;
+
             let mut pipeline_guard =
                 PipelineGuard::new(pipeline_clone.clone(), args.clone(), appstate_clone.clone());
 
@@ -38,6 +44,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 tracing::info!("Pipeline reaches EOS. Reset and rerun the pipeline.");
             }
+
+            sleep(Duration::from_secs(1)).await;
         }
     });
 

--- a/src/routes/whep_handler.rs
+++ b/src/routes/whep_handler.rs
@@ -59,9 +59,9 @@ pub async fn whep_handler<T: PipelineBase>(
 
             // Reset pipeline and app state if SDP offer is not received
             pipeline_state
-                .end()
+                .quit()
                 .await
-                .context("Failed to reset pipeline")?;
+                .context("Failed to stop pipeline")?;
 
             app_state
                 .reset()

--- a/src/routes/whep_handler.rs
+++ b/src/routes/whep_handler.rs
@@ -57,16 +57,16 @@ pub async fn whep_handler<T: PipelineBase>(
         Err(err) => {
             tracing::error!("Failed to receive SDP offer from WHIP sink: {}", err);
 
-            // Remove connection from pipeline and app state if SDP offer is not received
+            // Reset pipeline and app state if SDP offer is not received
             pipeline_state
-                .remove_connection(id.clone())
+                .end()
                 .await
-                .context("Failed to remove connection from pipeline")?;
+                .context("Failed to reset pipeline")?;
 
             app_state
-                .remove_connection(id.clone())
+                .reset()
                 .await
-                .context("Failed to remove connection from app state")?;
+                .context("Failed to reset app state")?;
 
             Err(SubscribeError::ValidationError(MyError::OfferMissing))
         }

--- a/src/routes/whip_handler.rs
+++ b/src/routes/whip_handler.rs
@@ -55,9 +55,9 @@ pub async fn whip_handler<T: PipelineBase>(
 
             // Reset pipeline and app state if SDP answer is not received
             pipeline_state
-                .end()
+                .quit()
                 .await
-                .context("Failed to reset pipeline")?;
+                .context("Failed to stop pipeline")?;
 
             app_state
                 .reset()

--- a/src/routes/whip_handler.rs
+++ b/src/routes/whip_handler.rs
@@ -53,15 +53,16 @@ pub async fn whip_handler<T: PipelineBase>(
         Err(err) => {
             tracing::error!("No WHEP SDP answer received from client: {}", err);
 
+            // Reset pipeline and app state if SDP answer is not received
             pipeline_state
-                .remove_connection(conn_id.clone())
+                .end()
                 .await
-                .context("Failed to remove client")?;
+                .context("Failed to reset pipeline")?;
 
             app_state
-                .remove_connection(conn_id.clone())
+                .reset()
                 .await
-                .context("Failed to remove connection")?;
+                .context("Failed to reset app state")?;
 
             Err(SubscribeError::ValidationError(MyError::AnswerMissing))
         }

--- a/src/stream/pipeline.rs
+++ b/src/stream/pipeline.rs
@@ -63,6 +63,7 @@ pub trait PipelineBase: Clone + Send + Sync {
     async fn run(&self) -> Result<(), Error>;
     async fn ready(&self) -> Result<bool, Error>;
     async fn end(&self) -> Result<(), Error>;
+    async fn quit(&self) -> Result<(), Error>;
     async fn clean_up(&self) -> Result<(), Error>;
 
     async fn print(&self) -> Result<(), Error>;
@@ -100,6 +101,10 @@ impl PipelineBase for DumpPipeline {
     }
 
     async fn end(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn quit(&self) -> Result<(), Error> {
         Ok(())
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
 use crate::domain::SharableAppState;
 use crate::stream::{Args, PipelineBase, SharablePipeline};
-use std::error::Error;
 use tokio_async_drop::tokio_async_drop;
 
 // Run the pipe and clean up when it finishes
@@ -20,7 +19,7 @@ impl PipelineGuard {
     }
 
     /// Run a pipeline until it encounters EOS or an error. Clean up the pipeline after it finishes.
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn run(&mut self) -> Result<(), anyhow::Error> {
         self.pipeline.init(&self.args).await?;
 
         // Block until EOS or error message pops up
@@ -30,7 +29,7 @@ impl PipelineGuard {
     }
 
     /// Clean up a pipeline on Drop.
-    async fn cleanup(&self) -> Result<(), Box<dyn Error>> {
+    async fn cleanup(&self) -> Result<(), anyhow::Error> {
         // Clean up the pipeline when it finishes so it can be rerun
         self.pipeline.clean_up().await?;
 


### PR DESCRIPTION
It has been reported that:

> The bridge has to be recreated regularly, usually after 1 - 1.5 hour, otherwise, any connection to it is simply impossible.

After some investigation, it turned out that sometimes the new-created `whipsink` in the pipeline does not generate the SDP offer as expected. This leaves the pipeline in a running state but the SRT source pad in a paused state, preventing any clients from joining afterwards.

The pipeline will now restart when the expected offer/answer is missing after a timeout to recover from this possible error.