### PR TITLE
feat(routes): idempotent DELETE — 204 for already-gone resource

### DIFF
--- a/docs/superpowers/plans/2026-07-10-idempotent-delete.md
+++ b/docs/superpowers/plans/2026-07-10-idempotent-delete.md
@@ -1,0 +1,170 @@
+# Idempotent DELETE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `DELETE /channel/{id}` and `DELETE /whip_sink/{id}` idempotent — a delete of an already-gone resource returns `204 No Content` instead of `404`, while a real termination keeps returning `200 OK`.
+
+**Architecture:** The idempotency policy lives at the HTTP edge (`src/routes/remove.rs`). The coordinator is unchanged: it still returns `Ok(())` when it tore a branch down and `Err(SignalError::NotFound)` when the id was unknown. The route handler maps `Ok(())` → `200`, `NotFound` → `204`, and propagates every other error unchanged (`503` retryable / `500` fatal).
+
+**Tech Stack:** Rust, actix-web, tokio. Fake `TestPipeline` drives the HTTP integration tests (no GStreamer needed for these tests).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-07-10-idempotent-delete-design.md`. Behavior contract, verbatim:
+  - Connection existed, torn down → `200 OK` (unchanged).
+  - Already gone / never existed → `204 No Content` (was `404`).
+  - Transient teardown failure → `503 + Retry-After` (unchanged — MUST NOT collapse to success).
+  - Coordinator gone / fatal pipeline error → `500` (unchanged).
+- **Do NOT change** `src/signal/coordinator.rs` (its `remove_connection` still returns `NotFound` for a missing id) or `src/signal/errors.rs` (the `NotFound → 404` mapping stays; PATCH relies on it).
+- **Test environment (macOS):** the integration tests link GStreamer dylibs; export this block before any `cargo` command or the binary aborts with `dyld: Library not loaded`:
+  ```sh
+  export PKG_CONFIG_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib/pkgconfig
+  export PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/bin:$PATH
+  export GST_PLUGIN_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib
+  export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GST_PLUGIN_PATH
+  export DYLD_FALLBACK_LIBRARY_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib
+  ```
+- **Working directory:** the isolated worktree at `.claude/worktrees/idempotent-delete` (branch `idempotent-delete`). All paths below are relative to it.
+- **Commit trailer:** end every commit message with:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
+  ```
+
+---
+
+### Task 1: Idempotent DELETE at the HTTP edge
+
+**Files:**
+- Modify: `src/routes/remove.rs` (the whole `remove_connection` handler body)
+- Test: `tests/signaling.rs` (add `delete_is_idempotent`; trim the DELETE arm from `unknown_ids_return_404`)
+
+**Interfaces:**
+- Consumes: `SignalHandle::remove_connection(id: String) -> Result<(), SignalError>` (unchanged) which returns `Ok(())` on teardown, `Err(SignalError::NotFound(id))` for an unknown id, `Err(SignalError::PipelineBusy(_))` on a transient teardown failure, and `Err(SignalError::Unavailable)`/`Pipeline(_)` on fatal errors.
+- Test helpers already in `tests/signaling.rs`: `spawn_app(functional_config()) -> (String, TestPipeline)`, `complete_exchange(&address, &pipeline, index).await -> String` (returns the connection id after a full WHEP↔WHIP exchange), `http_client() -> reqwest::Client`. `reqwest::StatusCode` is already imported at the top of the file. `pipeline.snapshot().removed` is a `Vec<String>` of torn-down ids.
+- Produces: no new public API — only the HTTP status contract changes.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this test to `tests/signaling.rs` (place it directly after `unknown_ids_return_404`, so the idempotent-delete behavior sits next to the 404 cases it replaces):
+
+```rust
+#[tokio::test]
+async fn delete_is_idempotent() {
+    let (address, pipeline) = spawn_app(functional_config());
+    let client = http_client();
+
+    let id = complete_exchange(&address, &pipeline, 0).await;
+
+    // First DELETE terminates a live session: 200, branch torn down.
+    let first = client
+        .delete(format!("{}/channel/{}", address, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::OK, first.status());
+    assert!(pipeline.snapshot().removed.contains(&id));
+
+    // Repeat DELETE of the same id: already gone -> 204 no-op, not 404.
+    let repeat = client
+        .delete(format!("{}/channel/{}", address, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::NO_CONTENT, repeat.status());
+
+    // DELETE of an id that never existed -> 204.
+    let ghost = client
+        .delete(format!("{}/channel/never-existed", address))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::NO_CONTENT, ghost.status());
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (with the GStreamer env from Global Constraints exported):
+```sh
+cargo test --test signaling delete_is_idempotent -- --nocapture
+```
+Expected: FAIL. The first `DELETE` returns `200` and the branch is removed, but the repeat `DELETE` returns `404`, so the test panics at `assert_eq!(StatusCode::NO_CONTENT, repeat.status())` (`left: 204, right: 404`).
+
+- [ ] **Step 3: Implement the idempotent handler**
+
+Replace the entire body of `src/routes/remove.rs` with:
+
+```rust
+use crate::signal::{SignalError, SignalHandle};
+use actix_web::{web, HttpResponse};
+
+/// DELETE is idempotent. Tearing down a live connection returns `200 OK`
+/// (the WHEP/WHIP-spec termination confirmation); a connection that is
+/// already gone — a client retry, or a session the coordinator already
+/// reaped — is a no-op that returns `204 No Content` instead of `404`.
+/// Retryable teardown failures (`503`) and fatal errors (`500`) are
+/// propagated unchanged.
+#[tracing::instrument(name = "REMOVE", skip(signal))]
+pub async fn remove_connection(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    match signal.remove_connection(id).await {
+        Ok(()) => Ok(HttpResponse::Ok().finish()),
+        Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),
+        Err(e) => Err(e),
+    }
+}
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run:
+```sh
+cargo test --test signaling delete_is_idempotent -- --nocapture
+```
+Expected: PASS (`test delete_is_idempotent ... ok`).
+
+- [ ] **Step 5: Trim the now-stale DELETE arm from `unknown_ids_return_404`**
+
+In `tests/signaling.rs`, `unknown_ids_return_404` still asserts `404` for a DELETE of a ghost id — now handled by `delete_is_idempotent`. Delete that arm (the `client.delete(format!("{}/channel/ghost", address))` block and its `assert_eq!(404, response.status());`). Keep the POST `/whip_sink/ghost` → `404` and PATCH `/channel/ghost` → `404` arms. Add a one-line comment where the DELETE arm was:
+
+```rust
+    // DELETE of an unknown id is idempotent (204), covered by delete_is_idempotent.
+```
+
+- [ ] **Step 6: Run the full suite to verify everything is green**
+
+Run:
+```sh
+cargo test
+```
+Expected: PASS. All lib + `signaling` integration tests pass (`tests/e2e_gstreamer.rs` stays `#[ignore]`d and does not run). Confirm `unknown_ids_return_404`, `list_and_delete_manage_the_connection_lifecycle`, and `whip_resource_location_is_routable_and_delete_removes_the_connection` are all green — the latter two still assert `200` on a successful DELETE and MUST remain unchanged.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add src/routes/remove.rs tests/signaling.rs
+git commit -m "$(cat <<'EOF'
+feat(routes): idempotent DELETE — 204 for already-gone resource
+
+DELETE /channel/{id} and /whip_sink/{id} now return 204 No Content when
+the connection is already gone or never existed, instead of 404. A real
+termination still returns 200 OK. Policy lives at the HTTP edge; the
+coordinator and error mapping are unchanged. Retryable (503) and fatal
+(500) paths are untouched.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
+EOF
+)"
+```
+
+---
+
+## Notes for the reviewer
+
+- The coordinator's `remove_connection` and its unit tests (`unknown_id_is_not_found_for_every_command`, `failed_delete_keeps_the_connection_retryable`) are deliberately untouched and must stay green. If either changed, the policy leaked out of the HTTP edge — reject.
+- Splitting the shared handler into separate WHEP and WHIP routes is explicitly out of scope (follow-up change). Both routes gain idempotency uniformly here.

--- a/docs/superpowers/specs/2026-07-10-idempotent-delete-design.md
+++ b/docs/superpowers/specs/2026-07-10-idempotent-delete-design.md
@@ -1,0 +1,128 @@
+# Idempotent DELETE
+
+**Date:** 2026-07-10
+**Status:** Approved — ready for implementation planning
+**Scope:** WHEP/WHIP resource teardown (`DELETE /channel/{id}` and `DELETE /whip_sink/{id}`)
+
+## Motivation
+
+A client (or a flaky network) may issue a DELETE for a session that is already
+gone — either because it retried, or because the coordinator itself already
+reaped the connection (bus-watch runtime failure, handshake-timeout sweep).
+Today that second DELETE returns `404 Not Found`, which reads as an error even
+though the client's intent — "make sure this session is gone" — is already
+satisfied.
+
+We want DELETE to be idempotent in the sense that matters (RFC 9110): repeating
+it leaves server state unchanged and returns a success code, so a retry or a
+race with internal cleanup is never surfaced as a client error.
+
+### Spec grounding
+
+This is a **robustness/interop improvement, not a compliance fix**. Both specs
+were checked:
+
+- **WHIP (RFC 9725)** and the **WHEP draft (draft-ietf-wish-whep, §4.4)** each
+  say only that the server responds with `200 OK` to confirm session
+  termination.
+- Neither spec addresses repeated DELETEs or an already-gone resource. Under
+  standard HTTP semantics (RFC 9110) a `404` for a non-existent resource is
+  legal, so today's behavior is already spec-compliant.
+
+Because the specs are silent on the already-gone case, returning a success code
+there is a free choice, not a divergence.
+
+## Behavior contract
+
+Both `DELETE /channel/{id}` (WHEP viewer) and `DELETE /whip_sink/{id}` (internal
+loopback WHIP bridge) currently share one handler; this design keeps that shared
+handler. (Splitting WHEP vs WHIP is a separate, follow-up change.)
+
+| Situation                                   | Before               | After                          |
+|---------------------------------------------|----------------------|--------------------------------|
+| Connection existed, torn down               | `200 OK`             | `200 OK` (unchanged)           |
+| Already gone / never existed                | `404 Not Found`      | **`204 No Content`**           |
+| Teardown failed transiently                 | `503 + Retry-After`  | `503 + Retry-After` (unchanged)|
+| Coordinator gone / fatal pipeline error     | `500`                | `500` (unchanged)              |
+
+- `200` is reserved for a real termination — we actually tore down a live
+  session. This is exactly what the WHIP/WHEP specs name for that case.
+- `204` signals an idempotent no-op — there was nothing to terminate. A client
+  can distinguish a first delete (`200`) from a redundant one (`204`); this is
+  useful signal, not a violation of idempotency.
+- The retryable (`503`) and fatal (`500`) paths are deliberately untouched. In
+  particular, a transient teardown failure must NOT be collapsed into a success
+  code — the caller should retry (see
+  `failed_delete_keeps_the_connection_retryable`).
+
+## Design: decide at the HTTP edge (Approach A)
+
+The idempotency policy is an HTTP-contract decision, so it lives at the HTTP
+boundary. The coordinator stays honest: `remove_connection` continues to return
+`Ok(())` when it tore a branch down and `Err(NotFound)` when the id was not in
+its map. The route handler translates that domain result into the HTTP contract
+above.
+
+### The one code change
+
+`src/routes/remove.rs` — replace the current `?`-and-`200` body:
+
+```rust
+match signal.remove_connection(id).await {
+    Ok(())                        => Ok(HttpResponse::Ok().finish()),         // 200: terminated a live session
+    Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),  // 204: idempotent no-op
+    Err(e)                        => Err(e),                                  // 503 (retryable) / 500 stay as-is
+}
+```
+
+The coordinator already hands the route exactly the distinction it needs
+(`Ok(())` vs `Err(NotFound)`), so no plumbing is added.
+
+### Explicitly unchanged
+
+- **`src/signal/coordinator.rs`** — `remove_connection` semantics are untouched;
+  a missing id still yields `NotFound`. This is the payoff of deciding at the
+  edge: the domain layer keeps telling the truth.
+- **`src/signal/errors.rs`** — the `NotFound → 404` mapping stays, because
+  **PATCH** (`answer_received`) still relies on it to return `404` for an
+  unknown id. Only the DELETE route reinterprets `NotFound`.
+- The retryable/fatal error paths.
+
+### Why not decide in the coordinator
+
+Making the coordinator return `Ok(())` for a missing id would bake an
+HTTP-shaped decision into the domain layer, force a split of the
+`unknown_id_is_not_found_for_every_command` unit test, and make both DELETE
+routes share one hard-coded policy — working against the planned WHEP/WHIP
+handler split, where each edge should pick its own policy. Deciding at the edge
+avoids all three.
+
+## Test plan
+
+**Integration (`tests/signaling.rs`):**
+
+- `unknown_ids_return_404` — remove the DELETE-of-ghost arm (currently asserts
+  `404`). Keep the POST-ghost and PATCH-ghost arms asserting `404`. Rename if
+  the remaining arms no longer justify the name.
+- New `delete_is_idempotent` — establish a connection, then assert:
+  1. DELETE the live id → `200`, and the branch is removed from the pipeline.
+  2. DELETE the same id again → `204` (already gone).
+  3. DELETE a never-existed ghost id → `204`.
+- `list_and_delete_manage_the_connection_lifecycle` (successful DELETE) and
+  `whip_resource_location_is_routable_and_delete_removes_the_connection`
+  (successful DELETE) — **unchanged**; both still assert `200`.
+
+**Unit (`src/signal/coordinator.rs`):** no changes.
+
+- `unknown_id_is_not_found_for_every_command` — stays green; the coordinator
+  still returns `NotFound` for a ghost remove.
+- `failed_delete_keeps_the_connection_retryable` — stays green; transient
+  teardown failure still yields `PipelineBusy`, not a success code.
+
+## Out of scope
+
+- Splitting the shared handler into distinct WHEP and WHIP routes (follow-up
+  change #2). This design intentionally keeps the shared handler so both routes
+  gain idempotency uniformly for now.
+- Any change to the `200` success code, the `503`/`500` error paths, or the
+  coordinator's teardown/retry logic.

--- a/src/routes/remove.rs
+++ b/src/routes/remove.rs
@@ -1,12 +1,21 @@
 use crate::signal::{SignalError, SignalHandle};
 use actix_web::{web, HttpResponse};
 
+/// DELETE is idempotent. Tearing down a live connection returns `200 OK`
+/// (the WHEP/WHIP-spec termination confirmation); a connection that is
+/// already gone — a client retry, or a session the coordinator already
+/// reaped — is a no-op that returns `204 No Content` instead of `404`.
+/// Retryable teardown failures (`503`) and fatal errors (`500`) are
+/// propagated unchanged.
 #[tracing::instrument(name = "REMOVE", skip(signal))]
 pub async fn remove_connection(
     path: web::Path<String>,
     signal: web::Data<SignalHandle>,
 ) -> Result<HttpResponse, SignalError> {
     let id = path.into_inner();
-    signal.remove_connection(id).await?;
-    Ok(HttpResponse::Ok().finish())
+    match signal.remove_connection(id).await {
+        Ok(()) => Ok(HttpResponse::Ok().finish()),
+        Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),
+        Err(e) => Err(e),
+    }
 }

--- a/tests/signaling.rs
+++ b/tests/signaling.rs
@@ -227,12 +227,40 @@ async fn unknown_ids_return_404() {
         .unwrap();
     assert_eq!(404, response.status());
 
-    let response = client
-        .delete(format!("{}/channel/ghost", address))
+    // DELETE of an unknown id is idempotent (204), covered by delete_is_idempotent.
+}
+
+#[tokio::test]
+async fn delete_is_idempotent() {
+    let (address, pipeline) = spawn_app(functional_config());
+    let client = http_client();
+
+    let id = complete_exchange(&address, &pipeline, 0).await;
+
+    // First DELETE terminates a live session: 200, branch torn down.
+    let first = client
+        .delete(format!("{}/channel/{}", address, id))
         .send()
         .await
         .unwrap();
-    assert_eq!(404, response.status());
+    assert_eq!(StatusCode::OK, first.status());
+    assert!(pipeline.snapshot().removed.contains(&id));
+
+    // Repeat DELETE of the same id: already gone -> 204 no-op, not 404.
+    let repeat = client
+        .delete(format!("{}/channel/{}", address, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::NO_CONTENT, repeat.status());
+
+    // DELETE of an id that never existed -> 204.
+    let ghost = client
+        .delete(format!("{}/channel/never-existed", address))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::NO_CONTENT, ghost.status());
 }
 
 #[tokio::test]

--- a/tests/signaling.rs
+++ b/tests/signaling.rs
@@ -3,7 +3,7 @@ use reqwest::StatusCode;
 use srt_whep::domain::{VALID_WHEP_ANSWER, VALID_WHIP_OFFER};
 use srt_whep::signal::CoordinatorConfig;
 use srt_whep::startup::Application;
-use srt_whep::stream::TestPipeline;
+use srt_whep::stream::{PipelineError, TestPipeline};
 use srt_whep::telemetry::{get_subscriber, init_subscriber};
 use std::net::TcpListener;
 use std::time::Duration;
@@ -261,6 +261,25 @@ async fn delete_is_idempotent() {
         .await
         .unwrap();
     assert_eq!(StatusCode::NO_CONTENT, ghost.status());
+}
+
+#[tokio::test]
+async fn delete_with_transient_teardown_failure_returns_503() {
+    let (address, pipeline) = spawn_app(functional_config());
+    let client = http_client();
+
+    let id = complete_exchange(&address, &pipeline, 0).await;
+
+    // The next branch teardown fails transiently: DELETE must surface a
+    // retryable 503 (+ Retry-After), NOT collapse into a success code.
+    pipeline.fail_next_remove_branch(PipelineError::Transient("lock timed out".into()));
+    let response = client
+        .delete(format!("{}/channel/{}", address, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(503, response.status().as_u16());
+    assert_eq!("3", response.headers()["Retry-After"].to_str().unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Makes `DELETE /channel/{id}` (WHEP) and `DELETE /whip_sink/{id}` (WHIP loopback) idempotent.

| Situation | Before | After |
|---|---|---|
| Connection existed, torn down | `200 OK` | `200 OK` (unchanged) |
| Already gone / never existed | `404 Not Found` | **`204 No Content`** |
| Transient teardown failure | `503 + Retry-After` | `503 + Retry-After` (unchanged) |
| Coordinator gone / fatal | `500` | `500` (unchanged) |

A repeated DELETE — a client retry, or a race where the coordinator already reaped the session (bus-watch reap / handshake-timeout sweep) — is now a `204` no-op instead of a confusing `404`. A real termination still returns `200`, which is what WHIP (RFC 9725) and the WHEP draft name.

## Why

Robustness/interop, **not** a spec-compliance fix: both specs mandate only `200` on a successful termination (already satisfied) and are silent on repeated/already-gone DELETEs, so `404` was already legal. `204` there is a free, friendlier choice for clients that retry.

## How

The idempotency policy lives at the HTTP edge (`src/routes/remove.rs`): the coordinator still returns `NotFound` for a missing id (unchanged), and the handler maps `Ok(())` → `200`, `NotFound` → `204`, and propagates every other error. `src/signal/coordinator.rs` and `src/signal/errors.rs` are untouched — the `NotFound → 404` mapping stays for PATCH.

## Tests

- `delete_is_idempotent` — real delete → `200`, repeat of the same id → `204`, never-existed id → `204`.
- `delete_with_transient_teardown_failure_returns_503` — guards the safety invariant that a transient teardown failure surfaces as `503 + Retry-After` and never collapses to a success code.
- Full suite green (52 lib + 14 integration; `e2e_gstreamer` remains `#[ignore]`d).

## Out of scope

Splitting the shared handler into distinct WHEP and WHIP routes is a separate follow-up (change #2). Both routes gain idempotency uniformly here.

Design + plan committed on the branch: `docs/superpowers/specs/2026-07-10-idempotent-delete-design.md`, `docs/superpowers/plans/2026-07-10-idempotent-delete.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
