### PR TITLE
refactor(routes): split DELETE into terminate_session + remove_whip_sink

### DIFF
--- a/docs/superpowers/plans/2026-07-10-whep-whip-delete-split.md
+++ b/docs/superpowers/plans/2026-07-10-whep-whip-delete-split.md
@@ -1,0 +1,155 @@
+# Split WHEP vs WHIP DELETE Handlers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the shared `remove_connection` DELETE handler into two intent-named, separately-instrumented handlers (`terminate_session` for WHEP, `remove_whip_sink` for WHIP), delegating to one shared idempotency helper — with the HTTP behavior unchanged.
+
+**Architecture:** Behavior-preserving refactor at the HTTP edge. `src/routes/remove.rs` gains a private `delete` helper holding the PR #111 idempotency match; two thin public handlers wrap it, each with its own `#[tracing::instrument]` span and an intent log line. `src/startup.rs` repoints the two DELETE routes. Nothing else changes.
+
+**Tech Stack:** Rust, actix-web, tokio, tracing. Fake `TestPipeline` drives the HTTP integration tests.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-07-10-whep-whip-delete-split-design.md`.
+- **Behavior is unchanged** — the HTTP contract stays exactly as PR #111 left it: `200` (torn down) / `204` (already gone) / `503 + Retry-After` (transient) / `500` (fatal). This is purely an observability + naming refactor.
+- **DRY:** the idempotency match lives in exactly ONE place (the private `delete` helper). Do NOT inline/duplicate it in the two handlers.
+- **Do NOT change** `src/signal/coordinator.rs`, `src/signal/errors.rs`, or any existing test. The existing DELETE integration tests are the regression guard and must stay green **unchanged**.
+- **No new tests** — there is no new behavior to test; a green existing suite is the proof the refactor preserved behavior.
+- **Test environment (macOS) — REQUIRED before any `cargo` command**, or the test binary aborts with `dyld: Library not loaded`:
+  ```sh
+  export PKG_CONFIG_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib/pkgconfig
+  export PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/bin:$PATH
+  export GST_PLUGIN_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib
+  export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GST_PLUGIN_PATH
+  export DYLD_FALLBACK_LIBRARY_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib
+  ```
+- **Working directory:** the worktree `.claude/worktrees/whep-whip-delete-split` (branch `whep-whip-delete-split`, based on `idempotent-delete`). All paths below are relative to it.
+- **Commit trailer** — end the commit message with:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
+  ```
+
+---
+
+### Task 1: Split the DELETE handler
+
+**Files:**
+- Modify: `src/routes/remove.rs` (replace the whole file body)
+- Modify: `src/startup.rs:25` and `:27` (repoint the two DELETE routes)
+
+**Interfaces:**
+- Consumes: `SignalHandle::remove_connection(id: String) -> Result<(), SignalError>` (unchanged coordinator method — NOT the route handler being replaced).
+- Produces: two public handlers re-exported via `crate::routes::*` — `terminate_session(path: web::Path<String>, signal: web::Data<SignalHandle>) -> Result<HttpResponse, SignalError>` and `remove_whip_sink(...)` with the same signature. The private `delete` helper is not exported. The old public `remove_connection` route handler is removed.
+
+- [ ] **Step 1: Rewrite `src/routes/remove.rs`**
+
+Replace the entire contents of `src/routes/remove.rs` with:
+
+```rust
+use crate::signal::{SignalError, SignalHandle};
+use actix_web::{web, HttpResponse};
+
+/// The shared idempotent-DELETE mapping (single source of the PR #111 policy):
+/// `Ok(())` → 200 (terminated a live session), `NotFound` → 204 (already gone,
+/// a no-op), and every other error propagates unchanged (503 retryable / 500
+/// fatal). Both DELETE routes go through here so the contract cannot diverge.
+async fn delete(id: String, signal: &SignalHandle) -> Result<HttpResponse, SignalError> {
+    match signal.remove_connection(id).await {
+        Ok(()) => Ok(HttpResponse::Ok().finish()),
+        Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),
+        Err(e) => Err(e),
+    }
+}
+
+/// A WHEP viewer terminating its playback session (`DELETE /channel/{id}`).
+#[tracing::instrument(name = "WHEP DELETE", skip(signal))]
+pub async fn terminate_session(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("WHEP client terminating session {}", id);
+    delete(id, &signal).await
+}
+
+/// The internal loopback whipclientsink tearing down its leg
+/// (`DELETE /whip_sink/{id}`).
+#[tracing::instrument(name = "WHIP SINK DELETE", skip(signal))]
+pub async fn remove_whip_sink(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("Removing WHIP sink for connection {}", id);
+    delete(id, &signal).await
+}
+```
+
+Note: `delete(id, &signal)` relies on `web::Data<SignalHandle>` deref-coercing to `&SignalHandle`. If the compiler objects, use `delete(id, signal.get_ref()).await`.
+
+- [ ] **Step 2: Repoint the two DELETE routes in `src/startup.rs`**
+
+Change the two DELETE route registrations (currently both `.to(remove_connection)`):
+
+```rust
+            .route("/channel/{id}", web::delete().to(terminate_session))
+```
+and
+```rust
+            .route(WHIP_SINK_ROUTE, web::delete().to(remove_whip_sink))
+```
+
+Leave every other route (`/list`, POST `/channel`, OPTIONS, PATCH, POST `WHIP_SINK_ROUTE`) untouched. No import change is needed — `terminate_session` and `remove_whip_sink` arrive via the existing `use crate::routes::*;` glob.
+
+- [ ] **Step 3: Confirm no dangling reference to the old route handler**
+
+Run:
+```sh
+rg -n "\bremove_connection\b" src/
+```
+Expected: every remaining hit is the coordinator method — `signal.remove_connection(...)` (in `remove.rs` and `coordinator.rs`), the method definition in `src/signal/mod.rs`, `Command::RemoveConnection` dispatch, and coordinator tests. There must be **no** `.to(remove_connection)` in `startup.rs` and **no** free `pub async fn remove_connection` in `routes/`.
+
+- [ ] **Step 4: Build and lint (with the GStreamer env exported)**
+
+Run:
+```sh
+cargo build 2>&1 | tail -20
+cargo clippy --all-targets 2>&1 | rg -E "warning|error" || echo "clippy clean"
+```
+Expected: builds with no errors; clippy reports no warnings (no unused imports, no dead code). If clippy flags anything introduced by this change, fix it.
+
+- [ ] **Step 5: Run the full suite — existing behavior must be preserved**
+
+Run:
+```sh
+cargo test > /tmp/whep-whip-split-test.log 2>&1; echo "EXIT=$?"
+rg -E "test result|FAILED|^error|panicked|delete_is_idempotent|delete_with_transient|list_and_delete|whip_resource_location" /tmp/whep-whip-split-test.log
+```
+Expected: `EXIT=0`. All lib tests and all `signaling` integration tests pass, unchanged (52 lib + 14 signaling as of the base commit; `e2e_gstreamer` stays `#[ignore]`d). In particular `delete_is_idempotent`, `delete_with_transient_teardown_failure_returns_503`, `list_and_delete_manage_the_connection_lifecycle`, and `whip_resource_location_is_routable_and_delete_removes_the_connection` must all be `ok` — they exercise both split routes through HTTP and prove the contract is preserved.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add src/routes/remove.rs src/startup.rs
+git commit -m "$(cat <<'EOF'
+refactor(routes): split DELETE into terminate_session + remove_whip_sink
+
+The shared remove_connection handler becomes two intent-named handlers with
+distinct tracing spans (WHEP DELETE / WHIP SINK DELETE), both delegating to a
+single private `delete` helper that holds the idempotency mapping. HTTP
+behavior is unchanged; the existing DELETE integration tests are the guard.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
+EOF
+)"
+```
+
+---
+
+## Notes for the reviewer
+
+- This branch is stacked on `idempotent-delete`. Review only THIS task's diff (base = the spec commit `790d992`) and, for the whole-branch review, base against the `idempotent-delete` fork point (`04f4e12`) — NOT `merge-base main HEAD`, which would drag in all of PR #111's commits.
+- The change must be behavior-preserving: if any existing DELETE test needed editing to stay green, that is a red flag — the refactor changed behavior and should be rejected.
+- Verify the idempotency match appears exactly once (in `delete`), not duplicated across the two handlers.

--- a/docs/superpowers/specs/2026-07-10-whep-whip-delete-split-design.md
+++ b/docs/superpowers/specs/2026-07-10-whep-whip-delete-split-design.md
@@ -1,0 +1,139 @@
+# Split WHEP vs WHIP DELETE handlers
+
+**Date:** 2026-07-10
+**Status:** Approved — ready for implementation planning
+**Scope:** `src/routes/remove.rs`, `src/startup.rs`
+**Depends on:** the idempotent-DELETE change (branch `idempotent-delete`, PR #111). This branch is based on `idempotent-delete`, not `main`, because it refactors the exact handler that change introduced.
+
+## Motivation
+
+Both DELETE routes currently dispatch to one shared handler, `remove_connection`:
+
+- `DELETE /channel/{id}` — a WHEP viewer terminating its playback session (client-facing).
+- `DELETE /whip_sink/{id}` — the internal loopback `whipclientsink` tearing down its leg.
+
+They are indistinguishable in traces and logs (one `REMOVE` span) and the single
+name says nothing about which caller it serves. This change splits them for two
+reasons, both chosen explicitly:
+
+- **Observability** — distinct tracing spans and log lines so a client
+  terminating a session is separable from the internal sink teardown.
+- **Clarity / maintainability** — two intent-revealing names that each say what
+  the DELETE means.
+
+This is **not** a behavior change. The HTTP contract is identical to what PR #111
+established and must stay identical.
+
+## Behavior contract — unchanged
+
+Both routes keep the exact idempotent-DELETE contract from PR #111:
+
+| Situation                                | Status                |
+|------------------------------------------|-----------------------|
+| Connection existed, torn down            | `200 OK`              |
+| Already gone / never existed             | `204 No Content`      |
+| Transient teardown failure               | `503 + Retry-After`   |
+| Coordinator gone / fatal pipeline error  | `500`                 |
+
+No status, path, coordinator, or error-mapping change. The idempotency match
+stays in exactly one place so its safety invariant (a transient failure must not
+collapse into a success code) cannot drift between the two routes.
+
+## Design
+
+Replace the single public `remove_connection` in `src/routes/remove.rs` with one
+shared private helper plus two intent-named, separately-instrumented public
+handlers.
+
+```rust
+use crate::signal::{SignalError, SignalHandle};
+use actix_web::{web, HttpResponse};
+
+/// The shared idempotent-DELETE mapping (single source of the PR #111 policy):
+/// `Ok(())` → 200 (terminated a live session), `NotFound` → 204 (already gone,
+/// a no-op), and every other error propagates unchanged (503 retryable / 500
+/// fatal). Both DELETE routes go through here so the contract cannot diverge.
+async fn delete(id: String, signal: &SignalHandle) -> Result<HttpResponse, SignalError> {
+    match signal.remove_connection(id).await {
+        Ok(()) => Ok(HttpResponse::Ok().finish()),
+        Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),
+        Err(e) => Err(e),
+    }
+}
+
+/// A WHEP viewer terminating its playback session (`DELETE /channel/{id}`).
+#[tracing::instrument(name = "WHEP DELETE", skip(signal))]
+pub async fn terminate_session(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("WHEP client terminating session {}", id);
+    delete(id, &signal).await
+}
+
+/// The internal loopback whipclientsink tearing down its leg
+/// (`DELETE /whip_sink/{id}`).
+#[tracing::instrument(name = "WHIP SINK DELETE", skip(signal))]
+pub async fn remove_whip_sink(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("Removing WHIP sink for connection {}", id);
+    delete(id, &signal).await
+}
+```
+
+`&signal` deref-coerces `web::Data<SignalHandle>` to `&SignalHandle` at the call
+site (`web::Data<T>: Deref<Target = T>`); the implementer may use
+`signal.get_ref()` if clearer.
+
+Routing in `src/startup.rs` re-points the two DELETE routes:
+
+```rust
+.route("/channel/{id}", web::delete().to(terminate_session))   // was remove_connection
+.route(WHIP_SINK_ROUTE,  web::delete().to(remove_whip_sink))    // was remove_connection
+```
+
+### File organization
+
+All three (`delete` helper + both handlers) stay in `src/routes/remove.rs`, a
+cohesive "deletion" module — least churn, and the shared helper's callers stay
+together. `mod.rs` still `pub use remove::*`, which now re-exports
+`terminate_session` and `remove_whip_sink` (the `delete` helper stays private).
+
+Considered and rejected: co-locating `terminate_session` into `whep_handler.rs`
+and `remove_whip_sink` into `whip_handler.rs`. That would help the future
+whepserversink migration (ADR 0001) delete the WHIP path as one file, but that
+migration was not a motivation here, and the split would separate the shared
+helper from its callers.
+
+## Test plan
+
+**No new tests.** This is a behavior-preserving refactor; the existing DELETE
+integration tests in `tests/signaling.rs` are exactly the regression guard and
+must stay green **unchanged**:
+
+- `delete_is_idempotent` — WHEP route: 200 / 204 / 204.
+- `delete_with_transient_teardown_failure_returns_503` — the 503 safety invariant.
+- `list_and_delete_manage_the_connection_lifecycle` — WHEP successful delete → 200.
+- `whip_resource_location_is_routable_and_delete_removes_the_connection` — WHIP
+  route successful delete → 200.
+
+These already exercise both routes through HTTP, so a green run after the split
+proves the contract is preserved. The observability change (span/log names) is
+verified by inspection, not by brittle log-assertion tests.
+
+The only code-level checks worth confirming during implementation:
+
+- `remove_connection` (the old route handler name) has no remaining references
+  after `startup.rs` is repointed. The `SignalHandle::remove_connection` method
+  is a different symbol and stays.
+- `cargo clippy` is clean (no unused imports, no dead code).
+
+## Out of scope
+
+- Any behavior/status change (that was PR #111).
+- Co-locating handlers by protocol / the whepserversink WHIP-path removal.
+- Per-route policy differences — the two handlers deliberately share `delete`.

--- a/src/routes/remove.rs
+++ b/src/routes/remove.rs
@@ -1,21 +1,37 @@
 use crate::signal::{SignalError, SignalHandle};
 use actix_web::{web, HttpResponse};
 
-/// DELETE is idempotent. Tearing down a live connection returns `200 OK`
-/// (the WHEP/WHIP-spec termination confirmation); a connection that is
-/// already gone — a client retry, or a session the coordinator already
-/// reaped — is a no-op that returns `204 No Content` instead of `404`.
-/// Retryable teardown failures (`503`) and fatal errors (`500`) are
-/// propagated unchanged.
-#[tracing::instrument(name = "REMOVE", skip(signal))]
-pub async fn remove_connection(
-    path: web::Path<String>,
-    signal: web::Data<SignalHandle>,
-) -> Result<HttpResponse, SignalError> {
-    let id = path.into_inner();
+/// The shared idempotent-DELETE mapping (single source of the PR #111 policy):
+/// `Ok(())` → 200 (terminated a live session), `NotFound` → 204 (already gone,
+/// a no-op), and every other error propagates unchanged (503 retryable / 500
+/// fatal). Both DELETE routes go through here so the contract cannot diverge.
+async fn delete(id: String, signal: &SignalHandle) -> Result<HttpResponse, SignalError> {
     match signal.remove_connection(id).await {
         Ok(()) => Ok(HttpResponse::Ok().finish()),
         Err(SignalError::NotFound(_)) => Ok(HttpResponse::NoContent().finish()),
         Err(e) => Err(e),
     }
+}
+
+/// A WHEP viewer terminating its playback session (`DELETE /channel/{id}`).
+#[tracing::instrument(name = "WHEP DELETE", skip(signal))]
+pub async fn terminate_session(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("WHEP client terminating session {}", id);
+    delete(id, &signal).await
+}
+
+/// The internal loopback whipclientsink tearing down its leg
+/// (`DELETE /whip_sink/{id}`).
+#[tracing::instrument(name = "WHIP SINK DELETE", skip(signal))]
+pub async fn remove_whip_sink(
+    path: web::Path<String>,
+    signal: web::Data<SignalHandle>,
+) -> Result<HttpResponse, SignalError> {
+    let id = path.into_inner();
+    tracing::info!("Removing WHIP sink for connection {}", id);
+    delete(id, &signal).await
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -22,9 +22,9 @@ pub fn run(listener: TcpListener, signal: SignalHandle) -> Result<Server, std::i
             .route("/channel", web::post().to(whep_handler))
             .route("/channel", web::route().guard(guard::Options()).to(options))
             .route("/channel/{id}", web::patch().to(whep_patch_handler))
-            .route("/channel/{id}", web::delete().to(remove_connection))
+            .route("/channel/{id}", web::delete().to(terminate_session))
             .route(WHIP_SINK_ROUTE, web::post().to(whip_handler))
-            .route(WHIP_SINK_ROUTE, web::delete().to(remove_connection))
+            .route(WHIP_SINK_ROUTE, web::delete().to(remove_whip_sink))
             .app_data(web::Data::new(signal.clone()))
     })
     // Shutdown is owned by Application::run_until_stopped (one Ctrl-C);


### PR DESCRIPTION
## What

Behavior-preserving refactor: splits the shared `remove_connection` DELETE handler into two intent-named handlers with distinct tracing spans.

- `DELETE /channel/{id}` → `terminate_session` (span `WHEP DELETE`) — a WHEP viewer terminating its playback session.
- `DELETE /whip_sink/{id}` → `remove_whip_sink` (span `WHIP SINK DELETE`) — the internal loopback whipclientsink tearing down its leg.

Both delegate to one private `delete` helper that holds the idempotency mapping, so the contract has a single source of truth and can't drift between routes.

## Why

**Observability + clarity.** The two routes were indistinguishable in traces/logs (one `REMOVE` span) and the single name said nothing about which caller it served. Now a client session teardown is cleanly separable from the internal sink teardown, and each handler's name states its intent.

## Behavior: unchanged

The HTTP contract is identical to #111 (`200` torn down / `204` already gone / `503 + Retry-After` transient / `500` fatal). git shows the idempotency match relocated as **unchanged context lines** — not a rewrite. No coordinator, error-mapping, or test changes.

## Tests

No new tests — this is behavior-preserving. The existing DELETE integration tests are the regression guard and stay green **unchanged**; they exercise both split routes over HTTP (`terminate_session` via the `/channel/{id}` cases, `remove_whip_sink` via `whip_resource_location_is_routable_and_delete_removes_the_connection`). Full suite: 52 lib + 14 signaling green, `e2e_gstreamer` ignored, clippy clean.

## Stacked on #111

> ⚠️ **Base is `idempotent-delete`, not `main`.** This is stacked on #111 (idempotent DELETE), which it refactors. Merge #111 first; GitHub will then auto-retarget this PR to `main`, at which point it shows only these 3 commits (spec, plan, refactor).

Design + plan on the branch: `docs/superpowers/specs/2026-07-10-whep-whip-delete-split-design.md`, `docs/superpowers/plans/2026-07-10-whep-whip-delete-split.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGVHhYpRBESwq7VLfTMLTn
