### PR TITLE
refactor(stream): extract the bus quit-vs-reap policy into a pure classifier (D2)

### DIFF
--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -37,6 +37,24 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   are now pinned through `SignalHandle`, including the watchdog-feeding
   row; `Termination` added to the CONTEXT.md glossary.
 
+- **D2 — landed (2026-07-12, PR #117).** `classify_bus_message(&gst::Message)
+  -> BusAction {Quit | ReapBranch(BranchId) | Ignore}` extracted from the
+  `bus_watch` closure; the closure is now a thin dispatch that executes the
+  action and logs. Two placements decided in design review (approved by
+  Kun): the classifier lives in a **new `stream::bus` module** rather than
+  in `naming` — `naming`'s "pure string logic, no GStreamer types" doc
+  property was worth keeping, so `bus` sits on top of it — and **EOS moved
+  into the classifier** as a `Quit` classification, so the closure retains
+  no match on message shape beyond log formatting. Unit tests (7) cover
+  EOS, direct and nested branch errors, core-element errors, source-less
+  errors (fatal — previously an untested edge), and non-lifecycle messages;
+  the C1 const-based naming-invariant test now has its hierarchy-level
+  completion (`containment_scope_holds_at_the_hierarchy_level`). Same
+  location-not-behavior discipline as D1: ADR-0002's containment scope is
+  concentrated, not changed. Verified: 61 lib + 14 integration green, the
+  manual `--ignored` e2e (`pipeline_survives_repeated_handshake_failures`)
+  passed, and the browser media guard passed (frames 0→95 climbing).
+
 ---
 
 ## Required reading before touching code

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -1,0 +1,169 @@
+//! Policy for the pipeline's bus watch: what a bus message means for the
+//! pipeline's fate, decided as a pure classification so the containment
+//! guarantee is unit-testable without SRT or a live peer.
+//!
+//! An error from a WHEP output branch (a `whip-sink-*`/`*-queue-*` element or
+//! anything nested inside it -- e.g. its signaller timing out or its peer
+//! going away) must not be fatal. Quitting the main loop would drop the SRT
+//! ingest and every other viewer, and the ensuing supervisor restart would
+//! reset all in-flight handshakes -- the "wedge" a single bad peer must never
+//! be able to cause (ADR 0002). Instead the error source's ancestry is walked
+//! to find which viewer's branch it belongs to, so the coordinator can reap
+//! that one connection while the pipeline stays up. Errors from core
+//! (viewer-independent) elements stay fatal, as does end-of-stream.
+//!
+//! The decision lives here; the mechanism (`main_loop.quit()`, the reap
+//! channel `try_send`) stays with the bus watch in `gst_pipeline.rs`.
+
+use gst::prelude::*;
+use gstreamer as gst;
+
+use crate::stream::naming::{self, BranchId};
+
+/// What the bus watch must do with one bus message.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BusAction {
+    /// Stop the pipeline: end of stream, or a fatal error from a core
+    /// (viewer-independent) element. The supervisor restarts from there.
+    Quit,
+    /// One viewer's branch failed at runtime: ask the coordinator to reap
+    /// exactly that branch. The pipeline stays up.
+    ReapBranch(BranchId),
+    /// Not lifecycle-relevant.
+    Ignore,
+}
+
+/// Classify one bus message into the action the watch must take.
+///
+/// Pure -- no side effects, no locks -- so it is safe on the GLib loop thread
+/// and testable with a hand-built element hierarchy. For an error message the
+/// source's ancestry is walked upward until a branch-derived name
+/// ([`naming::branch_id_from_name`]) identifies the owning viewer; an error
+/// that reaches the top without a match (a core element, or no source at all)
+/// is fatal.
+pub(crate) fn classify_bus_message(msg: &gst::Message) -> BusAction {
+    use gst::MessageView;
+
+    match msg.view() {
+        MessageView::Eos(..) => BusAction::Quit,
+        MessageView::Error(err) => {
+            let mut cursor = err.src().cloned();
+            while let Some(obj) = cursor {
+                if let Some(id) = naming::branch_id_from_name(obj.name().as_str()) {
+                    return BusAction::ReapBranch(BranchId::new(id));
+                }
+                cursor = obj.parent();
+            }
+            BusAction::Quit
+        }
+        _ => BusAction::Ignore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gst::prelude::*;
+
+    fn named_bin(name: &str) -> gst::Bin {
+        gst::init().unwrap();
+        gst::Bin::builder().name(name).build()
+    }
+
+    fn error_from(src: &gst::Bin) -> gst::Message {
+        gst::message::Error::builder(gst::CoreError::Failed, "boom")
+            .src(src)
+            .build()
+    }
+
+    #[test]
+    fn branch_element_error_reaps_only_that_branch() {
+        let queue = named_bin(&naming::video_queue_name("abc"));
+        assert_eq!(
+            BusAction::ReapBranch(BranchId::new("abc")),
+            classify_bus_message(&error_from(&queue))
+        );
+    }
+
+    #[test]
+    fn error_nested_inside_a_branch_walks_up_to_its_branch() {
+        // The real failure mode: the whip sink is a bin, and what errors is
+        // some element buried inside it (its signaller, an internal webrtcbin)
+        // whose own name says nothing about the viewer.
+        let sink = named_bin(&naming::whip_sink_name("abc"));
+        let inner = named_bin("some-internal-element");
+        sink.add(&inner).unwrap();
+        assert_eq!(
+            BusAction::ReapBranch(BranchId::new("abc")),
+            classify_bus_message(&error_from(&inner))
+        );
+    }
+
+    #[test]
+    fn core_element_error_is_fatal() {
+        let queue = named_bin(naming::VIDEO_QUEUE);
+        assert_eq!(BusAction::Quit, classify_bus_message(&error_from(&queue)));
+    }
+
+    #[test]
+    fn error_without_a_source_is_fatal() {
+        gst::init().unwrap();
+        let msg = gst::message::Error::builder(gst::CoreError::Failed, "boom").build();
+        assert_eq!(BusAction::Quit, classify_bus_message(&msg));
+    }
+
+    #[test]
+    fn eos_quits() {
+        gst::init().unwrap();
+        assert_eq!(
+            BusAction::Quit,
+            classify_bus_message(&gst::message::Eos::builder().build())
+        );
+    }
+
+    #[test]
+    fn other_messages_are_ignored() {
+        gst::init().unwrap();
+        assert_eq!(
+            BusAction::Ignore,
+            classify_bus_message(&gst::message::Buffering::builder(50).build())
+        );
+    }
+
+    #[test]
+    fn containment_scope_holds_at_the_hierarchy_level() {
+        // ADR 0002's containment scope, asserted through the classifier the
+        // bus watch actually runs -- against the naming consts/derivations
+        // (not literals), so this breaks the instant a rename splits the two.
+        // Every core element error must stay fatal...
+        for name in [
+            naming::DEMUX,
+            naming::VIDEO_QUEUE,
+            naming::AUDIO_QUEUE,
+            naming::OUTPUT_TEE_VIDEO,
+            naming::OUTPUT_TEE_AUDIO,
+            naming::SRT_SOURCE,
+        ] {
+            let bin = named_bin(name);
+            assert_eq!(
+                BusAction::Quit,
+                classify_bus_message(&error_from(&bin)),
+                "{name} must be fatal"
+            );
+        }
+        // ...and every branch-derived element error must reap its viewer.
+        for name in [
+            naming::whip_sink_name("abc"),
+            naming::video_queue_name("abc"),
+            naming::audio_queue_name("abc"),
+            naming::video_decoder_name("abc"),
+        ] {
+            let bin = named_bin(&name);
+            assert_eq!(
+                BusAction::ReapBranch(BranchId::new("abc")),
+                classify_bus_message(&error_from(&bin)),
+                "{name} must be contained"
+            );
+        }
+    }
+}

--- a/src/stream/gst_pipeline.rs
+++ b/src/stream/gst_pipeline.rs
@@ -8,6 +8,7 @@ use timed_locks::Mutex;
 use tokio::sync::mpsc;
 
 use crate::stream::branch::Branch;
+use crate::stream::bus::{classify_bus_message, BusAction};
 use crate::stream::errors::{PipelineError, StreamError};
 use crate::stream::naming::{self, BranchId};
 use crate::stream::pipeline::{Args, BranchControl, PipelineLifecycle, SRTMode};
@@ -491,59 +492,44 @@ impl PipelineLifecycle for SharablePipeline {
             use gst::MessageView;
 
             let main_loop = &main_loop_clone;
-            match msg.view() {
-                MessageView::Eos(..) => {
-                    tracing::info!("received eos");
-                    // An EndOfStream event was sent to the pipeline, so we tell our main loop
-                    // to stop execution here.
+            // The quit-vs-reap-vs-ignore decision (ADR 0002's containment
+            // scope) lives in `bus::classify_bus_message`; this closure only
+            // executes the chosen action and logs the message it holds.
+            match classify_bus_message(msg) {
+                BusAction::Quit => {
+                    match msg.view() {
+                        MessageView::Eos(..) => tracing::info!("received eos"),
+                        MessageView::Error(err) => tracing::error!(
+                            "{:?} runs into error : {} ({:?})",
+                            err.src().map(|s| s.path_string()),
+                            err.error(),
+                            err.debug()
+                        ),
+                        _ => (),
+                    }
                     main_loop.quit();
                 }
-                MessageView::Error(err) => {
-                    // An error from a WHEP output branch (a `whip-sink-*`/`*-queue-*`
-                    // element or anything nested inside it — e.g. its signaller timing
-                    // out or its peer going away) must not be fatal. Quitting the main
-                    // loop here would drop the SRT ingest and every other viewer, and
-                    // the ensuing supervisor restart would reset all in-flight
-                    // handshakes — the "wedge" a single bad peer must never be able to
-                    // cause. Instead we walk the error source's ancestry to find which
-                    // viewer's branch it belongs to and ask the coordinator to reap
-                    // that one connection, leaving the pipeline running.
-                    let src = err.src();
-                    let mut branch_id: Option<String> = None;
-                    let mut cursor = src.cloned();
-                    while let Some(obj) = cursor {
-                        if let Some(id) = naming::branch_id_from_name(obj.name().as_str()) {
-                            branch_id = Some(id.to_string());
-                            break;
-                        }
-                        cursor = obj.parent();
-                    }
-
-                    if let Some(id) = branch_id {
+                BusAction::ReapBranch(id) => {
+                    if let MessageView::Error(err) = msg.view() {
                         tracing::warn!(
                             "Branch for {} errored; reaping it, pipeline stays up: {} ({:?})",
-                            id,
+                            id.as_str(),
                             err.error(),
                             err.debug()
                         );
-                        // Fire-and-forget: the coordinator removes the branch and
-                        // drops the connection. `try_send` never blocks the GLib
-                        // loop thread; a full/closed channel just means the reap is
-                        // dropped (the sweep/DELETE remain a backstop).
-                        if branch_failures.try_send(BranchId::new(id.clone())).is_err() {
-                            tracing::warn!("Could not signal coordinator to reap branch {}", id);
-                        }
-                    } else {
-                        tracing::error!(
-                            "{:?} runs into error : {} ({:?})",
-                            src.as_ref().map(|s| s.path_string()),
-                            err.error(),
-                            err.debug()
+                    }
+                    // Fire-and-forget: the coordinator removes the branch and
+                    // drops the connection. `try_send` never blocks the GLib
+                    // loop thread; a full/closed channel just means the reap is
+                    // dropped (the sweep/DELETE remain a backstop).
+                    if branch_failures.try_send(id.clone()).is_err() {
+                        tracing::warn!(
+                            "Could not signal coordinator to reap branch {}",
+                            id.as_str()
                         );
-                        main_loop.quit();
                     }
                 }
-                _ => (),
+                BusAction::Ignore => (),
             };
 
             // Tell the mainloop to continue executing this callback.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,4 +1,5 @@
 mod branch;
+mod bus;
 mod errors;
 mod gst_pipeline;
 mod naming;

--- a/src/stream/naming.rs
+++ b/src/stream/naming.rs
@@ -1,7 +1,8 @@
 //! Single source of truth for GStreamer element names in the stream plane, and
-//! the classifier that decides whether a bus error belongs to one viewer's
-//! branch (reap just that branch) or the core demux->tee chain (fatal ->
-//! supervisor restart).
+//! the name-level classifier (`branch_id_from_name`) that decides whether one
+//! element name belongs to a viewer's branch. Its hierarchy-level completion
+//! -- walking a bus error's ancestry to a reap-or-quit decision -- is
+//! `bus::classify_bus_message`, built on top of it.
 //!
 //! Branch element names are DERIVED from the core stems, so the load-bearing
 //! relationship -- a branch queue is exactly `<core-queue-name>-<id>`, and the
@@ -72,9 +73,10 @@ impl BranchId {
 /// '-'. A core queue named exactly `video-queue` strips to "" and the missing
 /// '-' makes it return `None` -- that is what keeps a core-queue error fatal.
 ///
-/// The bus watch uses this to contain a dying branch's errors to that branch
-/// (reaping just that connection) instead of quitting the whole pipeline, which
-/// would drop the SRT ingest and every other viewer.
+/// `bus::classify_bus_message` runs this on every name in an error source's
+/// ancestry to contain a dying branch's errors to that branch (reaping just
+/// that connection) instead of quitting the whole pipeline, which would drop
+/// the SRT ingest and every other viewer.
 pub(crate) fn branch_id_from_name(name: &str) -> Option<&str> {
     for stem in [WHIP_SINK_STEM, VIDEO_QUEUE, AUDIO_QUEUE, VIDEO_DECODER_STEM] {
         if let Some(id) = name


### PR DESCRIPTION
Round-2 architecture deepening, candidate **D2** from
`docs/proposals/2026-07-11-architecture-deepening-candidates.md`.

## What

The `bus_watch` closure in `gst_pipeline.rs` fused the *decision* — quit-all
vs reap-one vs ignore, i.e. ADR-0002's containment scope — with the
*mechanism* (`main_loop.quit()`, the reap channel `try_send`). The ancestry
walk that maps a nested branch element's error to its viewer was exercised
only by the `#[ignore]` e2e; `TestPipeline` bypasses it entirely.

The decision now lives in a new `stream::bus` module as a pure

```rust
fn classify_bus_message(msg: &gst::Message) -> BusAction { Quit | ReapBranch(BranchId) | Ignore }
```

and the closure is a thin dispatch that executes the action and logs.
`stream::bus` is the hierarchy-level completion of `naming::branch_id_from_name`'s
single-name classification, built on top of it.

## Design decisions (grilled + approved)

- **New module, not inside `naming`** — `naming`'s "pure string logic, no
  GStreamer types" doc property is worth keeping; its tests stay
  string-only, `bus`'s tests build fake `gst::Bin` hierarchies.
- **EOS moved into the classifier** as a `Quit` classification, so the
  closure retains no match on message shape beyond log formatting.

Same location-not-behavior discipline as D1 (and C2a/ADR-0005): the
containment scope is concentrated, not changed. Behavior unchanged.

## Tests

7 new unit tests: EOS, direct branch error, error nested inside a branch bin
(the real failure mode), core-element error, source-less error (fatal —
previously an untested edge), non-lifecycle message, and
`containment_scope_holds_at_the_hierarchy_level` — the hierarchy-level
extension of C1's const-based naming invariant (every core name must
classify `Quit`, every branch-derived name `ReapBranch`).

## Verification

- `cargo test --all-targets`: 61 lib + 14 integration green, zero existing
  assertions modified
- Manual `--ignored` e2e: `pipeline_survives_repeated_handshake_failures` ok (18.9s)
- Browser media guard `tests/browser/run.sh`: **PASS** (frames 0→95 climbing,
  1280×720 H264)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV