### PR TITLE
refactor(supervisor): narrow the supervisor↔signal seam to a reset capability (D3)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,14 @@ viewer through a loopback WHIP bridge inside the same process.
   whether the watchdog is fed. The sweep and reap rows keep their pinned
   semantics; "a reap does not feed the watchdog" is a value in that table,
   not a comment.
+- **Reset** — the restart contract between the supervisor and the
+  coordinator: after *every* pipeline stop (error, EOS, watchdog restart,
+  shutdown) the supervisor resets signaling, and the coordinator fails all
+  in-flight waiters and clears the connection map — no waiter outlives the
+  pipeline run it was created against. Bounded by a timeout at the call
+  site so a wedged coordinator can't hang the restart loop. The supervisor
+  holds this as a one-method capability (`ResetSignal`, carried by
+  `ResetHandle`); the route-facing `SignalHandle` cannot reset.
 
 ## Terminology map: one lifecycle, three vantage points
 
@@ -85,7 +93,8 @@ elements. Do not introduce a fourth term.
 - `src/signal` — the coordinator actor; sole owner of connection state and
   the only caller of branch add/remove. HTTP handlers talk to it through
   `SignalHandle` (mpsc + oneshot replies), never touching pipeline state
-  directly.
+  directly; the supervisor holds the separate one-method `ResetHandle`
+  (`ResetSignal`), so only it can reset.
 - `src/stream` — the GStreamer pipeline. Two seams split by caller:
   `BranchControl` (the coordinator's per-connection view: `ready`,
   `add_branch`, `remove_branch`) and `PipelineLifecycle` (the supervisor's

--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -55,6 +55,27 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   manual `--ignored` e2e (`pipeline_survives_repeated_handshake_failures`)
   passed, and the browser media guard passed (frames 0→95 climbing).
 
+- **D3 — landed (2026-07-12, PR #118).** The supervisor now names a
+  one-method capability — `ResetSignal`, defined provider-side in
+  `signal/mod.rs`, matching where `BranchControl`/`PipelineLifecycle` live
+  in `stream` — instead of the whole six-method `SignalHandle`. Both wrong
+  widths fixed in one change (approved by Kun, incl. the card's optional
+  facade split): `spawn_coordinator` returns `(SignalHandle, ResetHandle)`
+  and `SignalHandle::reset()` is deleted, so the "supervisor only" doc
+  comment became structure — the routes' handle cannot reset. Two adapters
+  make the seam real: `ResetHandle` in production, a `RecordingReset` fake
+  in the supervisor tests, which no longer construct a coordinator.
+  Coverage moved to its owners: `reset_on_cleanup_fails_inflight_handshakes`
+  (a supervisor test standing up a real coordinator to prove a coordinator
+  behavior) is replaced by `reset_is_requested_after_every_stop`, which
+  pins the supervisor's side across all four stop kinds (error, EOS,
+  watchdog restart, shutdown); the waiter-failing side stays pinned by the
+  coordinator's own `reset_fails_all_waiters_and_clears_state`. The seam
+  also made the `RESET_TIMEOUT` bound testable for the first time
+  (`a_wedged_reset_does_not_hang_the_restart_loop`). `Reset` added to the
+  CONTEXT.md glossary. Verified: 62 lib + 14 integration green; signal/
+  supervisor plane only, no e2e needed (per the order table).
+
 ---
 
 ## Required reading before touching code

--- a/src/signal/coordinator.rs
+++ b/src/signal/coordinator.rs
@@ -672,7 +672,7 @@ mod tests {
     use super::ConnectionState;
     use super::CoordinatorConfig;
     use crate::domain::{SdpAnswer, SdpOffer, VALID_WHEP_ANSWER, VALID_WHIP_OFFER};
-    use crate::signal::{spawn_coordinator, SignalError, SignalHandle};
+    use crate::signal::{spawn_coordinator, ResetHandle, ResetSignal, SignalError, SignalHandle};
     use crate::stream::{BranchId, TestPipeline};
     use std::time::Duration;
     use tokio::sync::{mpsc, oneshot};
@@ -710,12 +710,20 @@ mod tests {
         pipeline: TestPipeline,
         config: CoordinatorConfig,
     ) -> (SignalHandle, mpsc::Receiver<()>) {
+        let (handle, _reset, restart_rx) = spawn_actor_with_reset(pipeline, config);
+        (handle, restart_rx)
+    }
+
+    /// Like `spawn_actor`, but also returns the supervisor-side `ResetHandle`
+    /// for tests that exercise the Reset command.
+    pub(super) fn spawn_actor_with_reset(
+        pipeline: TestPipeline,
+        config: CoordinatorConfig,
+    ) -> (SignalHandle, ResetHandle, mpsc::Receiver<()>) {
         let (_fail_tx, fail_rx) = mpsc::channel(1);
         let (restart_tx, restart_rx) = mpsc::channel(1);
-        (
-            spawn_coordinator(pipeline, config, fail_rx, restart_tx),
-            restart_rx,
-        )
+        let (handle, reset) = spawn_coordinator(pipeline, config, fail_rx, restart_tx);
+        (handle, reset, restart_rx)
     }
 
     /// Spawn the coordinator sharing `branch_failures` with a pipeline built via
@@ -726,10 +734,8 @@ mod tests {
         branch_failures: mpsc::Receiver<BranchId>,
     ) -> (SignalHandle, mpsc::Receiver<()>) {
         let (restart_tx, restart_rx) = mpsc::channel(1);
-        (
-            spawn_coordinator(pipeline, config, branch_failures, restart_tx),
-            restart_rx,
-        )
+        let (handle, _reset) = spawn_coordinator(pipeline, config, branch_failures, restart_tx);
+        (handle, restart_rx)
     }
 
     /// Drive a full WHEP<->WHIP handshake so the connection reaches Established.
@@ -1072,7 +1078,8 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn reset_clears_the_watchdog_counter() {
         let pipeline = ready_pipeline();
-        let (handle, mut restart_rx) = spawn_actor(pipeline.clone(), test_config()); // threshold 3
+        let (handle, reset, mut restart_rx) =
+            spawn_actor_with_reset(pipeline.clone(), test_config()); // threshold 3
 
         // Two consecutive timeout failures.
         for i in 0..2 {
@@ -1080,7 +1087,7 @@ mod tests {
         }
 
         // Pipeline restarted: supervisor sends Reset.
-        handle.reset().await.unwrap();
+        reset.reset().await.unwrap();
 
         // Two more failures on the fresh pipeline: still below threshold.
         for i in 2..4 {
@@ -1094,7 +1101,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn reset_fails_all_waiters_and_clears_state() {
         let pipeline = ready_pipeline();
-        let (handle, _restart_rx) = spawn_actor(pipeline.clone(), test_config());
+        let (handle, reset, _restart_rx) = spawn_actor_with_reset(pipeline.clone(), test_config());
 
         let whep = {
             let handle = handle.clone();
@@ -1102,7 +1109,7 @@ mod tests {
         };
         tokio::task::yield_now().await; // register the in-flight waiter
 
-        handle.reset().await.unwrap();
+        reset.reset().await.unwrap();
 
         assert!(matches!(whep.await.unwrap(), Err(SignalError::Unavailable)));
         assert!(list_ids(&handle).await.is_empty());

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -10,16 +10,45 @@ pub use messages::{ConnectionId, ConnectionInfo};
 
 use crate::domain::{SdpAnswer, SdpOffer};
 use crate::stream::{BranchControl, BranchId};
+use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
 
-/// Clone-able handle to the coordinator actor. HTTP handlers and the
-/// pipeline supervisor talk to the actor exclusively through this.
+/// Clone-able handle to the coordinator actor. HTTP handlers talk to the
+/// actor exclusively through this. It deliberately cannot reset the
+/// coordinator — that is the supervisor's capability, carried separately
+/// by [`ResetHandle`].
 #[derive(Clone)]
 pub struct SignalHandle {
     tx: mpsc::Sender<Command>,
 }
 
-/// Spawn the coordinator actor and return the handle for it. `branch_failures`
+/// The supervisor's view of signaling: reset after a pipeline stop. Failing
+/// all in-flight waiters and clearing the connection map is the coordinator's
+/// side of the restart contract — no waiter may outlive the pipeline run it
+/// was created against. [`ResetHandle`] is the production adapter; supervisor
+/// tests substitute a recording fake instead of standing up a coordinator.
+#[async_trait]
+pub trait ResetSignal: Send + Sync {
+    async fn reset(&self) -> Result<(), SignalError>;
+}
+
+/// The narrow handle carrying [`ResetSignal`] to the supervisor. It shares
+/// the coordinator's mailbox with [`SignalHandle`] but a reset is all it can
+/// request — the "supervisor only" guard on reset is structural, not a doc
+/// comment on a route-visible method.
+pub struct ResetHandle {
+    inner: SignalHandle,
+}
+
+#[async_trait]
+impl ResetSignal for ResetHandle {
+    async fn reset(&self) -> Result<(), SignalError> {
+        self.inner.request(|reply| Command::Reset { reply }).await
+    }
+}
+
+/// Spawn the coordinator actor and return its two handles: the route-facing
+/// [`SignalHandle`] and the supervisor's [`ResetHandle`]. `branch_failures`
 /// is the receiving end of the pipeline's bus-reap channel (its sender was
 /// handed to the pipeline at construction), so the sink is present from birth
 /// and no post-construction installer is needed. The watchdog trip sends a
@@ -29,10 +58,14 @@ pub fn spawn_coordinator<P: BranchControl + 'static>(
     config: CoordinatorConfig,
     branch_failures: mpsc::Receiver<BranchId>,
     restart_tx: mpsc::Sender<()>,
-) -> SignalHandle {
+) -> (SignalHandle, ResetHandle) {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(Coordinator::new(pipeline, config, rx, branch_failures, restart_tx).run());
-    SignalHandle { tx }
+    let handle = SignalHandle { tx };
+    let reset = ResetHandle {
+        inner: handle.clone(),
+    };
+    (handle, reset)
 }
 
 impl SignalHandle {
@@ -91,14 +124,6 @@ impl SignalHandle {
         self.request(|reply| Command::ListConnections { reply })
             .await
     }
-
-    /// Reset the coordinator after a pipeline restart (supervisor only).
-    /// Sends `Reset`, which fails all in-flight waiters and clears the
-    /// connection map; the reply is `Ok(())` once done, or an error if the
-    /// coordinator is unavailable.
-    pub async fn reset(&self) -> Result<(), SignalError> {
-        self.request(|reply| Command::Reset { reply }).await
-    }
 }
 
 #[cfg(test)]
@@ -116,7 +141,7 @@ mod tests {
         let (_fail_tx, fail_rx) = mpsc::channel(1);
         // This test never trips the watchdog: nothing consumes restarts.
         let (restart_tx, _restart_rx) = mpsc::channel::<()>(1);
-        let handle = spawn_coordinator(
+        let (handle, _reset) = spawn_coordinator(
             pipeline.clone(),
             CoordinatorConfig::default(),
             fail_rx,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -80,9 +80,10 @@ impl Application {
         // the force-quit + rerun). Created here so both ends exist before
         // either task is spawned — symmetric with the bus-reap channel.
         let (restart_tx, restart_rx) = mpsc::channel(1);
-        let signal = spawn_coordinator(pipeline.clone(), config, branch_failures, restart_tx);
+        let (signal, reset) =
+            spawn_coordinator(pipeline.clone(), config, branch_failures, restart_tx);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let supervisor = Supervisor::spawn(pipeline, signal.clone(), shutdown_rx, restart_rx);
+        let supervisor = Supervisor::spawn(pipeline, reset, shutdown_rx, restart_rx);
         let server = run(listener, signal.clone())?;
         Ok(Self {
             server,

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -3,7 +3,7 @@
 //!
 //! This is the one place that knows the restart policy, the cleanup/reset
 //! contract with the coordinator, and the shutdown ordering (EOS → join).
-use crate::signal::SignalHandle;
+use crate::signal::ResetSignal;
 use crate::stream::PipelineLifecycle;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
@@ -14,19 +14,19 @@ const MAX_RESTART_DELAY: Duration = Duration::from_secs(30);
 const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 const RESET_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub struct Supervisor<P: PipelineLifecycle> {
+pub struct Supervisor<P: PipelineLifecycle, S: ResetSignal> {
     pipeline: P,
-    signal: SignalHandle,
+    signal: S,
     shutdown: watch::Receiver<bool>,
     restart_rx: mpsc::Receiver<()>,
 }
 
-impl<P: PipelineLifecycle + 'static> Supervisor<P> {
+impl<P: PipelineLifecycle + 'static, S: ResetSignal + 'static> Supervisor<P, S> {
     /// Spawn the supervision loop. It runs until the shutdown channel reads
     /// `true` (or its sender is dropped).
     pub fn spawn(
         pipeline: P,
-        signal: SignalHandle,
+        signal: S,
         shutdown: watch::Receiver<bool>,
         restart_rx: mpsc::Receiver<()>,
     ) -> JoinHandle<()> {
@@ -194,29 +194,61 @@ fn flatten_join(
 #[cfg(test)]
 mod tests {
     use super::Supervisor;
-    use crate::signal::{spawn_coordinator, CoordinatorConfig, SignalError, SignalHandle};
+    use crate::signal::{ResetSignal, SignalError};
     use crate::stream::{TestPipeline, TestPipelineState};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::{mpsc, watch};
 
-    /// Build the coordinator + restart channel for a supervisor test. The
-    /// coordinator gets a disconnected failure receiver (never reaps); the
-    /// returned `restart_tx` lets a test drive a watchdog restart directly, and
-    /// `restart_rx` is handed to `Supervisor::spawn`.
-    fn wire(pipeline: TestPipeline) -> (SignalHandle, mpsc::Sender<()>, mpsc::Receiver<()>) {
-        let (_fail_tx, fail_rx) = mpsc::channel(1);
-        let (restart_tx, restart_rx) = mpsc::channel(1);
-        let signal = spawn_coordinator(
-            pipeline,
-            CoordinatorConfig::default(),
-            fail_rx,
-            restart_tx.clone(),
-        );
-        (signal, restart_tx, restart_rx)
+    /// Recording adapter for the supervisor's reset capability: counts the
+    /// reset calls; `wedged` makes them hang forever, standing in for a dead
+    /// coordinator. The coordinator's side of the contract is pinned by its
+    /// own tests — no coordinator is spawned here.
+    #[derive(Clone, Default)]
+    struct RecordingReset {
+        calls: Arc<AtomicU32>,
+        wedged: bool,
     }
 
+    impl RecordingReset {
+        fn wedged() -> Self {
+            Self {
+                calls: Arc::default(),
+                wedged: true,
+            }
+        }
+
+        fn count(&self) -> u32 {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ResetSignal for RecordingReset {
+        async fn reset(&self) -> Result<(), SignalError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.wedged {
+                std::future::pending::<()>().await;
+            }
+            Ok(())
+        }
+    }
+
+    /// Build the reset fake + restart channel for a supervisor test. The
+    /// returned `restart_tx` lets a test drive a watchdog restart directly,
+    /// and `restart_rx` is handed to `Supervisor::spawn`.
+    fn wire() -> (RecordingReset, mpsc::Sender<()>, mpsc::Receiver<()>) {
+        let (restart_tx, restart_rx) = mpsc::channel(1);
+        (RecordingReset::default(), restart_tx, restart_rx)
+    }
+
+    /// Poll under the paused clock until `f` holds. 1000 × 10ms sleeps give
+    /// a 10s virtual-time budget — enough to cross RESET_TIMEOUT (5s) plus a
+    /// restart backoff, which the wedged-reset test needs.
     async fn wait_until(pipeline: &TestPipeline, f: impl Fn(&TestPipelineState) -> bool) {
-        for _ in 0..500 {
+        for _ in 0..1000 {
             if f(&pipeline.snapshot()) {
                 return;
             }
@@ -228,9 +260,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn restarts_after_a_failed_run() {
         let pipeline = TestPipeline::default();
-        let (signal, _restart_tx, restart_rx) = wire(pipeline.clone());
+        let (reset, _restart_tx, restart_rx) = wire();
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-        let _sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let _sup = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
 
         wait_until(&pipeline, |s| s.run_count == 1).await;
         pipeline.fail_run("gst blew up");
@@ -242,31 +274,61 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn reset_on_cleanup_fails_inflight_handshakes() {
+    async fn reset_is_requested_after_every_stop() {
+        // The supervisor's side of the restart contract: signaling is reset
+        // after *every* stop — error, clean EOS, watchdog restart, shutdown —
+        // so no waiter outlives the run it was created against. The
+        // coordinator's side (a reset fails all in-flight waiters and clears
+        // the connection map) is pinned by
+        // `reset_fails_all_waiters_and_clears_state` in signal::coordinator.
         let pipeline = TestPipeline::default();
-        pipeline.set_ready(true);
-        let (signal, _restart_tx, restart_rx) = wire(pipeline.clone());
-        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-        let _sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let (reset, restart_tx, restart_rx) = wire();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let sup = Supervisor::spawn(pipeline.clone(), reset.clone(), shutdown_rx, restart_rx);
         wait_until(&pipeline, |s| s.run_count == 1).await;
 
-        let waiter = {
-            let signal = signal.clone();
-            tokio::spawn(async move { signal.create_connection("a".into()).await })
-        };
-        wait_until(&pipeline, |s| s.added.len() == 1).await;
+        pipeline.fail_run("gst blew up"); // stop 1: error
+        wait_until(&pipeline, |s| s.run_count == 2).await;
+        assert_eq!(1, reset.count());
+
+        pipeline.finish_run(); // stop 2: clean EOS
+        wait_until(&pipeline, |s| s.run_count == 3).await;
+        assert_eq!(2, reset.count());
+
+        restart_tx.send(()).await.unwrap(); // stop 3: watchdog restart
+        wait_until(&pipeline, |s| s.run_count == 4).await;
+        assert_eq!(3, reset.count());
+
+        shutdown_tx.send(true).unwrap(); // stop 4: shutdown
+        sup.await.unwrap();
+        assert_eq!(4, reset.count());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_wedged_reset_does_not_hang_the_restart_loop() {
+        // RESET_TIMEOUT is the bound at the cleanup site: a coordinator that
+        // never answers must not wedge the supervisor. The rerun still
+        // happens once the timeout fires (paused clock — the 5s elapse
+        // virtually).
+        let pipeline = TestPipeline::default();
+        let reset = RecordingReset::wedged();
+        let (_restart_tx, restart_rx) = mpsc::channel(1);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let _sup = Supervisor::spawn(pipeline.clone(), reset.clone(), shutdown_rx, restart_rx);
+        wait_until(&pipeline, |s| s.run_count == 1).await;
 
         pipeline.fail_run("gst blew up");
-        let result = waiter.await.unwrap();
-        assert!(matches!(result, Err(SignalError::Unavailable)));
+
+        wait_until(&pipeline, |s| s.run_count == 2).await;
+        assert_eq!(1, reset.count()); // attempted exactly once, then timed out
     }
 
     #[tokio::test(start_paused = true)]
     async fn shutdown_sends_eos_joins_and_stops_the_loop() {
         let pipeline = TestPipeline::default();
-        let (signal, _restart_tx, restart_rx) = wire(pipeline.clone());
+        let (reset, _restart_tx, restart_rx) = wire();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let sup = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
         wait_until(&pipeline, |s| s.run_count == 1).await;
 
         shutdown_tx.send(true).unwrap();
@@ -281,9 +343,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn dropped_shutdown_sender_also_stops_the_loop() {
         let pipeline = TestPipeline::default();
-        let (signal, _restart_tx, restart_rx) = wire(pipeline.clone());
+        let (reset, _restart_tx, restart_rx) = wire();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let sup = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
         wait_until(&pipeline, |s| s.run_count == 1).await;
 
         drop(shutdown_tx);
@@ -296,9 +358,9 @@ mod tests {
         // A watchdog restart request force-quits the run and reruns, exactly
         // like EOS — cleanup runs and the pipeline is rerun at base delay.
         let pipeline = TestPipeline::default();
-        let (signal, restart_tx, restart_rx) = wire(pipeline.clone());
+        let (reset, restart_tx, restart_rx) = wire();
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-        let _sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let _sup = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
         wait_until(&pipeline, |s| s.run_count == 1).await;
 
         restart_tx.send(()).await.unwrap();
@@ -311,9 +373,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn backoff_doubles_on_consecutive_failures_and_resets_on_success() {
         let pipeline = TestPipeline::default();
-        let (signal, _restart_tx, restart_rx) = wire(pipeline.clone());
+        let (reset, _restart_tx, restart_rx) = wire();
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-        let _sup = Supervisor::spawn(pipeline.clone(), signal.clone(), shutdown_rx, restart_rx);
+        let _sup = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
 
         wait_until(&pipeline, |s| s.run_count == 1).await;
         let t0 = tokio::time::Instant::now();


### PR DESCRIPTION
Third candidate from the [round-2 architecture-deepening proposal](https://github.com/Eyevinn/srt-whep/blob/main/docs/proposals/2026-07-11-architecture-deepening-candidates.md) (D3), following #116 (D1) and #117 (D2).

## Problem

Two widths wrong at once. The supervisor depended on the entire six-method `SignalHandle` to call exactly one method (`reset()`, its only production use), so every supervisor test had to stand up a full real coordinator just to obtain a handle. Meanwhile the HTTP routes held the *same* handle via `web::Data`, on which the supervisor-only `reset()` was guarded by nothing but a doc comment.

## Change

- **`ResetSignal`** — a one-method capability trait in `src/signal/mod.rs` (provider-side, matching where `BranchControl`/`PipelineLifecycle` live in `stream`). The supervisor is now `Supervisor<P: PipelineLifecycle, S: ResetSignal>`.
- **Facade split** (the card's optional half, done in the same change since the churn was small): `spawn_coordinator` returns `(SignalHandle, ResetHandle)` and `SignalHandle::reset()` is deleted. The "supervisor only" guard is now structural — the routes' handle simply cannot reset.
- **Two adapters make the seam real**: `ResetHandle` in production, a `RecordingReset` fake in the supervisor tests, which construct no coordinator.

## Tests

Coverage moved to its owners rather than being lost:

- `reset_on_cleanup_fails_inflight_handshakes` (a supervisor test proving a *coordinator* behavior through the stack) is replaced by `reset_is_requested_after_every_stop`, pinning the supervisor's side of the restart contract across all four stop kinds — error, clean EOS, watchdog restart, shutdown. The waiter-failing side stays pinned by the coordinator's own `reset_fails_all_waiters_and_clears_state`.
- **New pin the seam buys**: `a_wedged_reset_does_not_hang_the_restart_loop` exercises the `RESET_TIMEOUT` bound at the cleanup site — previously covered by no test, since wedging a real coordinator isn't practical.
- All other supervisor tests keep their names and assertions; only the wiring changed.

Location-not-behavior: no semantics change, no pipeline code touched.

## Verification

- `cargo test --all-targets`: 62 lib + 14 integration green (the integration suite drives the new `Application::assemble` wiring through the real coordinator, including the watchdog-restart path).
- clippy + fmt clean (pre-commit hooks).
- No e2e run needed per the proposal's order table (signal/supervisor plane only).

Docs: `Reset` added to the CONTEXT.md glossary; module map updated; proposal progress log records the design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV