### PR TITLE
refactor(stream): extract the egress codec table from init() into stream::egress (D4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,13 @@ viewer through a loopback WHIP bridge inside the same process.
 - **Branch** — that connection's per-viewer GStreamer elements
   (`whipclientsink` + queues) hot-plugged into the pipeline. One connection,
   one branch.
+- **Egress chain** — the per-media output chain built once the demux
+  announces the stream's pads (`src/stream/egress.rs`, the codec table):
+  video is parsed (`h264parse`/`h265parse`) into a named output tee; audio
+  is transcoded AAC → Opus into its own tee; unknown media is an error.
+  The named tees are the attach points for Branches, and the terminating
+  fakesink keeps each chain consuming — and pops EOS onto the bus when the
+  SRT input closes — even with zero viewers attached.
 - **Loopback WHIP** — the in-process `whipclientsink` POSTing its SDP offer
   back to this app's own HTTP server (`/whip_sink/{id}`) instead of to an
   external WHIP endpoint. This is how the WHEP-facing signaling plane gets
@@ -99,8 +106,10 @@ elements. Do not introduce a fourth term.
   `BranchControl` (the coordinator's per-connection view: `ready`,
   `add_branch`, `remove_branch`) and `PipelineLifecycle` (the supervisor's
   whole-pipeline view: `init`, `run`, `end`, `clean_up`, `quit`).
-  `src/stream/gst_pipeline.rs` holds the real implementation; `TestPipeline`
-  in `src/stream/pipeline.rs` is the recording fake both traits share for
+  `src/stream/gst_pipeline.rs` holds the real implementation, with the
+  codec decisions split out into `src/stream/egress.rs` (which parser or
+  transcode chain each demuxed media type gets); `TestPipeline` in
+  `src/stream/pipeline.rs` is the recording fake both traits share for
   tests.
 - `src/supervisor.rs` — the restart loop: `init` → `run` → `cleanup` (pipeline
   `clean_up` + `signal.reset()`) → backoff → repeat, until a `watch`

--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -76,6 +76,33 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   CONTEXT.md glossary. Verified: 62 lib + 14 integration green; signal/
   supervisor plane only, no e2e needed (per the order table).
 
+- **D4 — landed (2026-07-12, PR #119).** The codec table moved out of
+  `init()`'s `no_more_pads` closure into a new `stream::egress` module:
+  `build_egress_chain(pipeline, media_type, video_queue, audio_queue)`
+  owns media type → parser choice → chain construction → the
+  `sync_state_with_parent` invariant; the closure is now a thin dispatch
+  that walks the demux pads and logs, mirroring D2's decision/mechanism
+  split for the bus watch. Two placements decided in design review
+  (approved by Kun, both as recommended): a **new module** (the `bus.rs`
+  precedent — its own doc header, its own tests; `gst_pipeline.rs` shrinks
+  644 → 570 lines) and the **card's handle-threading signature** — `init()`
+  passes the queues it just built rather than the function re-finding them
+  by name, so the "queues already in the pipeline" precondition rides in
+  the arguments and no new `MissingElement` failure mode appears. The
+  extraction kept strictly to the card's scope: the static ingest topology
+  stays inline in `init()` (linear construction, no decisions — extraction
+  would just move code). Unit tests (4) cover the previously-e2e-only
+  table: h264 and h265 (asserting *which* parser the queue got linked to,
+  not just that a tee exists), the audio AAC→Opus transcode chain, and
+  unknown media as an error that builds nothing. Simpler than the card
+  guessed: no `tsdemux` + forced caps needed — the extracted signature
+  takes `media_type` as a string, so tests need only a pipeline with two
+  named queues. CI runs these everywhere (the PR workflow installs
+  base/good/bad/ugly/libav, and `bus.rs` set the `gst::init()` lib-test
+  precedent). `Egress chain` added to the CONTEXT.md glossary. Verified:
+  66 lib + 14 integration green, the manual `--ignored` e2e passed, and
+  the browser media guard passed (frames 0→148 climbing).
+
 ---
 
 ## Required reading before touching code

--- a/src/stream/egress.rs
+++ b/src/stream/egress.rs
@@ -1,0 +1,182 @@
+//! Egress chain construction -- the codec table.
+//!
+//! When the demux announces its pads, each media type gets an egress chain
+//! hung off its pre-built ingest queue: video is parsed (`h264parse` /
+//! `h265parse`) and fanned out through a named output tee; audio is transcoded
+//! AAC -> Opus and fanned out the same way. The named tees
+//! ([`naming::OUTPUT_TEE_VIDEO`] / [`naming::OUTPUT_TEE_AUDIO`]) are the
+//! attach points for WHEP branches; the terminating fakesink keeps each chain
+//! consuming buffers -- and pops EOS onto the message bus when the SRT input
+//! closes -- even with zero viewers attached.
+//!
+//! The decision (which parser, which chain, what counts as unsupported) lives
+//! here; the dispatch (walking the demux's src pads on no-more-pads) stays
+//! with `init()` in `gst_pipeline.rs`.
+
+use anyhow::Error;
+use gst::prelude::*;
+use gstreamer as gst;
+
+use crate::stream::errors::StreamError;
+use crate::stream::naming;
+
+/// Build and start the egress chain for one demuxed media type.
+///
+/// The queues are the ones `init()` already constructed and added to the
+/// pipeline -- this function links the new chain onto the matching one and
+/// leaves the other untouched. Every element it creates is synced to the
+/// pipeline's state before returning; without that the chain would sit in
+/// Null and never process data. Unknown media types are an error and build
+/// nothing.
+pub(crate) fn build_egress_chain(
+    pipeline: &gst::Pipeline,
+    media_type: &str,
+    video_queue: &gst::Element,
+    audio_queue: &gst::Element,
+) -> Result<(), Error> {
+    // Codec table: the video arms differ only in which parser element sits
+    // between the queue and the tee.
+    let video_parser = if media_type.starts_with("video/x-h264") {
+        Some("h264parse")
+    } else if media_type.starts_with("video/x-h265") {
+        tracing::warn!("H.265(HEVC) streams can be linked but are not fully supported yet");
+        Some("h265parse")
+    } else {
+        None
+    };
+
+    if let Some(parser) = video_parser {
+        let parse = gst::ElementFactory::make(parser).build()?;
+        let output_tee_video = gst::ElementFactory::make("tee")
+            .name(naming::OUTPUT_TEE_VIDEO)
+            .build()?;
+        // Add a fakesink to the end of pipeline to consume buffers
+        // it receives and pops EOS to message bus when the SRT input stream is closed
+        let fakesink = gst::ElementFactory::make("fakesink")
+            .property("can-activate-pull", true)
+            .build()?;
+
+        let video_elements = &[video_queue, &parse, &output_tee_video, &fakesink];
+        // 'video_queue' has been added to the pipeline already, so we don't add it again.
+        pipeline.add_many(&video_elements[1..])?;
+        gst::Element::link_many(&video_elements[..])?;
+        // This is quite important and people forget it often. Without making sure that
+        // the new elements have the same state as the pipeline, things will fail later.
+        // They would still be in Null state and can't process data.
+        for e in video_elements {
+            e.sync_state_with_parent()?;
+        }
+
+        Ok(())
+    } else if media_type.starts_with("audio") {
+        let aacparse = gst::ElementFactory::make("aacparse").build()?;
+        let avdec_aac = gst::ElementFactory::make("avdec_aac").build()?;
+        let audioconvert = gst::ElementFactory::make("audioconvert").build()?;
+        let audioresample = gst::ElementFactory::make("audioresample").build()?;
+        let opusenc = gst::ElementFactory::make("opusenc").build()?;
+        let output_tee_audio = gst::ElementFactory::make("tee")
+            .name(naming::OUTPUT_TEE_AUDIO)
+            .build()?;
+        let fakesink = gst::ElementFactory::make("fakesink")
+            .property("can-activate-pull", true)
+            .build()?;
+
+        let audio_elements = &[
+            audio_queue,
+            &aacparse,
+            &avdec_aac,
+            &audioconvert,
+            &audioresample,
+            &opusenc,
+            &output_tee_audio,
+            &fakesink,
+        ];
+        // 'audio_queue' has been added to the pipeline already, so we don't add it again.
+        pipeline.add_many(&audio_elements[1..])?;
+        gst::Element::link_many(&audio_elements[..])?;
+        for e in audio_elements {
+            e.sync_state_with_parent()?;
+        }
+
+        Ok(())
+    } else {
+        Err(StreamError::FailedOperation(format!("Unknown media type {}", media_type)).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pipeline holding the two pre-built ingest queues, exactly as `init()`
+    /// has them by the time the demux announces its pads.
+    fn pipeline_with_queues() -> (gst::Pipeline, gst::Element, gst::Element) {
+        gst::init().unwrap();
+        let pipeline = gst::Pipeline::default();
+        let video_queue = gst::ElementFactory::make("queue")
+            .name(naming::VIDEO_QUEUE)
+            .build()
+            .unwrap();
+        let audio_queue = gst::ElementFactory::make("queue")
+            .name(naming::AUDIO_QUEUE)
+            .build()
+            .unwrap();
+        pipeline.add_many([&video_queue, &audio_queue]).unwrap();
+        (pipeline, video_queue, audio_queue)
+    }
+
+    /// Factory name of the element the queue got linked to -- which parser
+    /// (or transcode head) the codec table picked.
+    fn linked_factory(queue: &gst::Element) -> String {
+        queue
+            .static_pad("src")
+            .unwrap()
+            .peer()
+            .expect("queue src pad should be linked")
+            .parent_element()
+            .unwrap()
+            .factory()
+            .unwrap()
+            .name()
+            .to_string()
+    }
+
+    #[test]
+    fn h264_is_parsed_into_the_video_tee() {
+        let (pipeline, video_queue, audio_queue) = pipeline_with_queues();
+        build_egress_chain(&pipeline, "video/x-h264", &video_queue, &audio_queue).unwrap();
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_VIDEO).is_some());
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_AUDIO).is_none());
+        assert_eq!("h264parse", linked_factory(&video_queue));
+    }
+
+    #[test]
+    fn h265_swaps_only_the_parser() {
+        let (pipeline, video_queue, audio_queue) = pipeline_with_queues();
+        build_egress_chain(&pipeline, "video/x-h265", &video_queue, &audio_queue).unwrap();
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_VIDEO).is_some());
+        assert_eq!("h265parse", linked_factory(&video_queue));
+    }
+
+    #[test]
+    fn audio_is_transcoded_into_the_audio_tee() {
+        let (pipeline, video_queue, audio_queue) = pipeline_with_queues();
+        build_egress_chain(&pipeline, "audio/mpeg", &video_queue, &audio_queue).unwrap();
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_AUDIO).is_some());
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_VIDEO).is_none());
+        // The transcode chain starts at the parser; WHEP delivers Opus, so the
+        // chain must re-encode rather than pass AAC through.
+        assert_eq!("aacparse", linked_factory(&audio_queue));
+    }
+
+    #[test]
+    fn unknown_media_is_an_error_and_builds_nothing() {
+        let (pipeline, video_queue, audio_queue) = pipeline_with_queues();
+        let result = build_egress_chain(&pipeline, "text/x-raw", &video_queue, &audio_queue);
+        assert!(result.is_err());
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_VIDEO).is_none());
+        assert!(pipeline.by_name(naming::OUTPUT_TEE_AUDIO).is_none());
+        assert!(!video_queue.static_pad("src").unwrap().is_linked());
+        assert!(!audio_queue.static_pad("src").unwrap().is_linked());
+    }
+}

--- a/src/stream/gst_pipeline.rs
+++ b/src/stream/gst_pipeline.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 
 use crate::stream::branch::Branch;
 use crate::stream::bus::{classify_bus_message, BusAction};
+use crate::stream::egress;
 use crate::stream::errors::{PipelineError, StreamError};
 use crate::stream::naming::{self, BranchId};
 use crate::stream::pipeline::{Args, BranchControl, PipelineLifecycle, SRTMode};
@@ -292,87 +293,12 @@ impl PipelineLifecycle for SharablePipeline {
                 let media_type = media_type.unwrap().as_str();
                 tracing::debug!("linking to media {:?}", media_type);
 
-                let link_media = |pipeline: &Pipeline, media_type: &str| -> Result<(), Error> {
-                    // Codec table: the video arms differ only in which
-                    // parser element sits between the queue and the tee.
-                    let video_parser = if media_type.starts_with("video/x-h264") {
-                        Some("h264parse")
-                    } else if media_type.starts_with("video/x-h265") {
-                        tracing::warn!(
-                            "H.265(HEVC) streams can be linked but are not fully supported yet"
-                        );
-                        Some("h265parse")
-                    } else {
-                        None
-                    };
-
-                    if let Some(parser) = video_parser {
-                        let parse = gst::ElementFactory::make(parser).build()?;
-                        let output_tee_video = gst::ElementFactory::make("tee")
-                            .name(naming::OUTPUT_TEE_VIDEO)
-                            .build()?;
-                        // Add a fakesink to the end of pipeline to consume buffers
-                        // it receives and pops EOS to message bus when the SRT input stream is closed
-                        let fakesink = gst::ElementFactory::make("fakesink")
-                            .property("can-activate-pull", true)
-                            .build()?;
-
-                        let video_elements = &[&video_queue, &parse, &output_tee_video, &fakesink];
-                        // 'video_queue' has been added to the pipeline already, so we don't add it again.
-                        pipeline.add_many(&video_elements[1..])?;
-                        gst::Element::link_many(&video_elements[..])?;
-                        // This is quite important and people forget it often. Without making sure that
-                        // the new elements have the same state as the pipeline, things will fail later.
-                        // They would still be in Null state and can't process data.
-                        for e in video_elements {
-                            e.sync_state_with_parent()?;
-                        }
-
-                        Ok(())
-                    } else if media_type.starts_with("audio") {
-                        let aacparse = gst::ElementFactory::make("aacparse").build()?;
-                        let avdec_aac = gst::ElementFactory::make("avdec_aac").build()?;
-                        let audioconvert = gst::ElementFactory::make("audioconvert").build()?;
-                        let audioresample = gst::ElementFactory::make("audioresample").build()?;
-                        let opusenc = gst::ElementFactory::make("opusenc").build()?;
-                        let output_tee_audio = gst::ElementFactory::make("tee")
-                            .name(naming::OUTPUT_TEE_AUDIO)
-                            .build()?;
-                        let fakesink = gst::ElementFactory::make("fakesink")
-                            .property("can-activate-pull", true)
-                            .build()?;
-
-                        let audio_elements = &[
-                            &audio_queue,
-                            &aacparse,
-                            &avdec_aac,
-                            &audioconvert,
-                            &audioresample,
-                            &opusenc,
-                            &output_tee_audio,
-                            &fakesink,
-                        ];
-                        // 'audio_queue' has been added to the pipeline already, so we don't add it again.
-                        pipeline.add_many(&audio_elements[1..])?;
-                        gst::Element::link_many(&audio_elements[..])?;
-                        for e in audio_elements {
-                            e.sync_state_with_parent()?;
-                        }
-
-                        Ok(())
-                    } else {
-                        Err(StreamError::FailedOperation(format!(
-                            "Unknown media type {}",
-                            media_type
-                        ))
-                        .into())
-                    }
-                };
-
-                let linked = link_media(&pipeline, media_type).map_err(|err| {
-                    tracing::error!("Failed to link media: {}", err);
-                    err
-                });
+                let linked =
+                    egress::build_egress_chain(&pipeline, media_type, &video_queue, &audio_queue)
+                        .map_err(|err| {
+                            tracing::error!("Failed to link media: {}", err);
+                            err
+                        });
 
                 linked.is_ok()
             });

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,5 +1,6 @@
 mod branch;
 mod bus;
+mod egress;
 mod errors;
 mod gst_pipeline;
 mod naming;


### PR DESCRIPTION
## What

Candidate **D4** from `docs/proposals/2026-07-11-architecture-deepening-candidates.md`: the codec decision table moves out of `init()`'s `no_more_pads` closure into a new `stream::egress` module.

`build_egress_chain(pipeline, media_type, video_queue, audio_queue)` now owns media type → parser choice (`h264parse`/`h265parse`) → chain construction (named output tee + fakesink; AAC→Opus transcode for audio) → the load-bearing `sync_state_with_parent` invariant. The closure inside `init()` is a thin dispatch that walks the demux pads and logs — the same decision/mechanism split the bus watch got in D2 (#117).

## Design decisions (approved in design review)

- **New module** (`src/stream/egress.rs`), following the `bus.rs` precedent: its own doc header explaining the decision/mechanism split, its own unit tests. `gst_pipeline.rs` shrinks 644 → 570 lines.
- **Handle-threading signature** (the card's shape): `init()` passes the queue handles it built four lines earlier rather than the function re-finding them by name — the "queues already in the pipeline" precondition rides in the arguments, and no new `MissingElement` failure mode appears.
- **Scope kept strictly to the card**: the static ingest topology stays inline in `init()` — linear construction, no decisions; extracting it would just move code.

Location, not behavior: the table's arms are byte-comparable to the closure's, and the unknown-media error is unchanged (`StreamError` hygiene is D5's card, deliberately not coupled here).

## Tests

The table was previously reachable only through the ignored e2e. New unit tests (4) pin it directly:

- `h264_is_parsed_into_the_video_tee` / `h265_swaps_only_the_parser` — assert **which** parser the queue got linked to, not just that a tee exists
- `audio_is_transcoded_into_the_audio_tee` — the chain starts at `aacparse` (WHEP delivers Opus; no AAC pass-through)
- `unknown_media_is_an_error_and_builds_nothing` — error path leaves both queues unlinked, no tees

These run in CI everywhere: the PR workflow installs base/good/bad/ugly/libav, and `bus.rs` already set the `gst::init()` lib-test precedent. `Egress chain` added to the CONTEXT.md glossary (the thing Branches attach to).

## Verification

- 66 lib + 14 integration tests green; clippy + fmt clean
- Manual `--ignored` e2e: `pipeline_survives_repeated_handshake_failures` passed (19s)
- Browser media guard: **PASS** — HTTP 201, connected, frames decoded 0 → 148 climbing, 1280×720 H264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV