### PR TITLE
refactor(errors): D5 — error taxonomy hygiene

### DIFF
--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -103,6 +103,33 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   66 lib + 14 integration green, the manual `--ignored` e2e passed, and
   the browser media guard passed (frames 0→148 climbing).
 
+- **D5 — landed (2026-07-12, PR #120).** Both halves, one commit each.
+  **(a)** `StreamError` deleted, per the card's "pick one honestly": the
+  re-verification against `ecd2174` found not just zero matches but zero
+  *possible* policy — every one of the 14 construction sites' honest
+  classification is Fatal (attach runs under the same lock as the
+  `input_ready()` check, so a missing tee mid-attach is genuine breakage,
+  not a race; the retryable cases were already constructed as
+  `PipelineError::NotReady`/`Transient` directly at the seam), and five
+  sites live inside `init()`'s GStreamer callbacks where the error only
+  feeds a log line. So option B ("make it drive policy") would have added
+  a downcast with identical arms — deletion chosen (approved by Kun).
+  Sites now use anyhow `context`/`anyhow!` with the "Failed to find
+  element: X" text kept verbatim so logs read the same; `stream::errors`
+  is now exactly the `BranchControl` seam language (`PipelineError`
+  alone). **(b)** The retryable set `{Timeout, NotReady, PipelineBusy}`
+  is spelled once: a private `SignalError::http_contract()` match returns
+  `(status, retry-after)` per variant, and both `ResponseError` methods
+  are accessors over it. Chosen over the card's literal `is_retryable()`
+  predicate (approved by Kun) because it keeps the match exhaustive — a
+  new variant forces deciding status and retryability in one arm, instead
+  of an early-return leaving unreachable arms or a drift-prone catch-all.
+  Contract tests at `signal/errors.rs` unchanged and green, pinning that
+  the refactor moved nothing observable. Verified: 66 lib + 14
+  integration green, clippy `-D warnings` clean, the manual `--ignored`
+  e2e passed (18.8s), and the browser media guard passed (frames 0→148
+  climbing).
+
 ---
 
 ## Required reading before touching code

--- a/src/signal/errors.rs
+++ b/src/signal/errors.rs
@@ -28,28 +28,36 @@ pub enum SignalError {
     Pipeline(String),
 }
 
-impl ResponseError for SignalError {
-    fn status_code(&self) -> StatusCode {
+impl SignalError {
+    /// The HTTP contract in one match: the status a failure gets, and the
+    /// Retry-After to attach when a retry is worthwhile. One arm decides
+    /// both for each variant, so the retryable set (503 + Retry-After) is
+    /// spelled exactly once and the two can never drift.
+    fn http_contract(&self) -> (StatusCode, Option<&'static str>) {
         match self {
-            SignalError::InvalidSdp(_) | SignalError::Sdp(_) => StatusCode::BAD_REQUEST,
-            SignalError::NotFound(_) => StatusCode::NOT_FOUND,
-            SignalError::WrongState(_) => StatusCode::CONFLICT,
+            SignalError::InvalidSdp(_) | SignalError::Sdp(_) => (StatusCode::BAD_REQUEST, None),
+            SignalError::NotFound(_) => (StatusCode::NOT_FOUND, None),
+            SignalError::WrongState(_) => (StatusCode::CONFLICT, None),
             SignalError::Timeout(_) | SignalError::NotReady | SignalError::PipelineBusy(_) => {
-                StatusCode::SERVICE_UNAVAILABLE
+                (StatusCode::SERVICE_UNAVAILABLE, Some("3"))
             }
             SignalError::Unavailable | SignalError::Pipeline(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
+                (StatusCode::INTERNAL_SERVER_ERROR, None)
             }
         }
     }
+}
+
+impl ResponseError for SignalError {
+    fn status_code(&self) -> StatusCode {
+        self.http_contract().0
+    }
 
     fn error_response(&self) -> HttpResponse {
-        let mut builder = HttpResponse::build(self.status_code());
-        if matches!(
-            self,
-            SignalError::Timeout(_) | SignalError::NotReady | SignalError::PipelineBusy(_)
-        ) {
-            builder.append_header(("Retry-After", "3"));
+        let (status, retry_after) = self.http_contract();
+        let mut builder = HttpResponse::build(status);
+        if let Some(seconds) = retry_after {
+            builder.append_header(("Retry-After", seconds));
         }
         builder.body(self.to_string())
     }

--- a/src/stream/branch.rs
+++ b/src/stream/branch.rs
@@ -16,11 +16,10 @@
 //! `startup.rs` imports [`WHIP_SINK_ROUTE`] and the WHIP handler imports
 //! [`whip_sink_path`], so the HTTP contract and the whipclientsink's endpoint
 //! can never drift apart.
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use gst::prelude::*;
 use gstreamer as gst;
 
-use crate::stream::errors::StreamError;
 use crate::stream::naming;
 
 /// The actix route template for the loopback WHIP endpoint — the single
@@ -85,7 +84,7 @@ impl Branch {
     ) -> Result<(), Error> {
         let demux = pipeline
             .by_name(naming::DEMUX)
-            .ok_or(StreamError::MissingElement(naming::DEMUX.to_string()))?;
+            .with_context(|| format!("Failed to find element: {}", naming::DEMUX))?;
         // WhipWebRTCSink is renamed as 'whipclientsink' since gst-plugin-webrtc version 0.13.0
         let whipsink = gst::ElementFactory::make("whipclientsink")
             .name(self.whip_sink_name())
@@ -109,12 +108,9 @@ impl Branch {
             .into_iter()
             .any(|pad| pad.name().starts_with("video"))
         {
-            let output_tee_video =
-                pipeline
-                    .by_name(naming::OUTPUT_TEE_VIDEO)
-                    .ok_or(StreamError::MissingElement(
-                        naming::OUTPUT_TEE_VIDEO.to_string(),
-                    ))?;
+            let output_tee_video = pipeline
+                .by_name(naming::OUTPUT_TEE_VIDEO)
+                .with_context(|| format!("Failed to find element: {}", naming::OUTPUT_TEE_VIDEO))?;
             let queue_video: gst::Element = gst::ElementFactory::make("queue")
                 .name(self.video_queue_name())
                 .build()?;
@@ -148,12 +144,9 @@ impl Branch {
             .into_iter()
             .any(|pad| pad.name().starts_with("audio"))
         {
-            let output_tee_audio =
-                pipeline
-                    .by_name(naming::OUTPUT_TEE_AUDIO)
-                    .ok_or(StreamError::MissingElement(
-                        naming::OUTPUT_TEE_AUDIO.to_string(),
-                    ))?;
+            let output_tee_audio = pipeline
+                .by_name(naming::OUTPUT_TEE_AUDIO)
+                .with_context(|| format!("Failed to find element: {}", naming::OUTPUT_TEE_AUDIO))?;
             let queue_audio: gst::Element = gst::ElementFactory::make("queue")
                 .name(self.audio_queue_name())
                 .build()?;
@@ -261,23 +254,19 @@ impl Branch {
         }
 
         let queue = queue.unwrap();
-        let queue_sink_pad =
-            queue
-                .static_pad("sink")
-                .ok_or(StreamError::MissingElement(format!(
-                    "{}'s sink pad",
-                    queue_name
-                )))?;
+        let queue_sink_pad = queue
+            .static_pad("sink")
+            .with_context(|| format!("Failed to find element: {}'s sink pad", queue_name))?;
 
         // Remove src pad from tee if queue is linked
         let name = queue_name.to_string();
         if queue_sink_pad.is_linked() {
             let tee_src_pad = queue_sink_pad
                 .peer()
-                .ok_or(StreamError::MissingElement("tee's src pad".to_string()))?;
+                .context("Failed to find element: tee's src pad")?;
             let tee = tee_src_pad
                 .parent_element()
-                .ok_or(StreamError::MissingElement("output_tee".to_string()))?;
+                .context("Failed to find element: output_tee")?;
 
             // Pause tee before removing pad and resume afterward
             tee.call_async_future(move |tee| {
@@ -297,11 +286,10 @@ impl Branch {
 
             Self::remove_element_from_pipeline(pipeline, &queue).await?;
         } else {
-            return Err(StreamError::FailedOperation(format!(
+            return Err(anyhow!(
                 "Queue {} is not linked and can not be removed.",
                 name
-            ))
-            .into());
+            ));
         }
 
         Ok(())

--- a/src/stream/egress.rs
+++ b/src/stream/egress.rs
@@ -13,11 +13,10 @@
 //! here; the dispatch (walking the demux's src pads on no-more-pads) stays
 //! with `init()` in `gst_pipeline.rs`.
 
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use gst::prelude::*;
 use gstreamer as gst;
 
-use crate::stream::errors::StreamError;
 use crate::stream::naming;
 
 /// Build and start the egress chain for one demuxed media type.
@@ -100,7 +99,7 @@ pub(crate) fn build_egress_chain(
 
         Ok(())
     } else {
-        Err(StreamError::FailedOperation(format!("Unknown media type {}", media_type)).into())
+        Err(anyhow!("Unknown media type {}", media_type))
     }
 }
 

--- a/src/stream/errors.rs
+++ b/src/stream/errors.rs
@@ -36,20 +36,3 @@ impl From<TimedLockError> for PipelineError {
         PipelineError::Transient(e.to_string())
     }
 }
-
-/// Stream-internal failure detail (GStreamer plumbing). Surfaces at the
-/// `BranchControl` seam as `PipelineError::Fatal` and through
-/// `PipelineLifecycle` inside `anyhow::Error`.
-#[derive(Error)]
-pub enum StreamError {
-    #[error("Failed to find element: {0}")]
-    MissingElement(String),
-    #[error("Failed Operation: {0}")]
-    FailedOperation(String),
-}
-
-impl Debug for StreamError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        error_chain_fmt(self, f)
-    }
-}

--- a/src/stream/gst_pipeline.rs
+++ b/src/stream/gst_pipeline.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use async_trait::async_trait;
 use gst::{prelude::*, Pipeline};
 use gstreamer as gst;
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 use crate::stream::branch::Branch;
 use crate::stream::bus::{classify_bus_message, BusAction};
 use crate::stream::egress;
-use crate::stream::errors::{PipelineError, StreamError};
+use crate::stream::errors::PipelineError;
 use crate::stream::naming::{self, BranchId};
 use crate::stream::pipeline::{Args, BranchControl, PipelineLifecycle, SRTMode};
 use crate::stream::utils::run_discoverer;
@@ -346,16 +346,12 @@ impl PipelineLifecycle for SharablePipeline {
                 if is_audio {
                     // Get the queue element's sink pad and link the decodebin's newly created
                     // src pad for the audio stream to it.
-                    let audio_queue = pipeline
-                        .by_name(naming::AUDIO_QUEUE)
-                        .ok_or(StreamError::MissingElement(naming::AUDIO_QUEUE.to_string()))?;
-                    let sink_pad =
-                        audio_queue
-                            .static_pad("sink")
-                            .ok_or(StreamError::MissingElement(format!(
-                                "{}'s sink pad",
-                                naming::AUDIO_QUEUE
-                            )))?;
+                    let audio_queue = pipeline.by_name(naming::AUDIO_QUEUE).with_context(|| {
+                        format!("Failed to find element: {}", naming::AUDIO_QUEUE)
+                    })?;
+                    let sink_pad = audio_queue.static_pad("sink").with_context(|| {
+                        format!("Failed to find element: {}'s sink pad", naming::AUDIO_QUEUE)
+                    })?;
                     src_pad.link(&sink_pad)?;
 
                     tracing::info!("Successfully inserted audio sink");
@@ -363,16 +359,12 @@ impl PipelineLifecycle for SharablePipeline {
                 if is_video {
                     // Get the queue element's sink pad and link the decodebin's newly created
                     // src pad for the video stream to it.
-                    let video_queue = pipeline
-                        .by_name(naming::VIDEO_QUEUE)
-                        .ok_or(StreamError::MissingElement(naming::VIDEO_QUEUE.to_string()))?;
-                    let sink_pad =
-                        video_queue
-                            .static_pad("sink")
-                            .ok_or(StreamError::MissingElement(format!(
-                                "{}'s sink pad",
-                                naming::VIDEO_QUEUE
-                            )))?;
+                    let video_queue = pipeline.by_name(naming::VIDEO_QUEUE).with_context(|| {
+                        format!("Failed to find element: {}", naming::VIDEO_QUEUE)
+                    })?;
+                    let sink_pad = video_queue.static_pad("sink").with_context(|| {
+                        format!("Failed to find element: {}'s sink pad", naming::VIDEO_QUEUE)
+                    })?;
                     src_pad.link(&sink_pad)?;
 
                     tracing::info!("Successfully inserted video sink");
@@ -402,9 +394,7 @@ impl PipelineLifecycle for SharablePipeline {
             let pipeline = pipeline_state
                 .pipeline
                 .as_ref()
-                .ok_or(StreamError::FailedOperation(
-                    "Pipeline called before initialization".to_string(),
-                ))?;
+                .context("Pipeline called before initialization")?;
             let bus = pipeline.bus().unwrap();
             let main_loop = glib::MainLoop::new(None, false);
             pipeline_state.main_loop = Some(main_loop.clone());
@@ -481,9 +471,9 @@ impl PipelineLifecycle for SharablePipeline {
                 }
             })?;
 
-        done_rx.await.map_err(|_| {
-            StreamError::FailedOperation("GLib main loop thread died unexpectedly".to_string())
-        })??;
+        done_rx
+            .await
+            .map_err(|_| anyhow!("GLib main loop thread died unexpectedly"))??;
 
         Ok(())
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -8,7 +8,7 @@ mod pipeline;
 mod utils;
 
 pub use branch::{whip_sink_path, WHIP_SINK_ROUTE};
-pub use errors::{PipelineError, StreamError};
+pub use errors::PipelineError;
 pub use gst_pipeline::*;
 pub use naming::BranchId;
 pub use pipeline::*;


### PR DESCRIPTION
Candidate **D5** from `docs/proposals/2026-07-11-architecture-deepening-candidates.md` — two independent halves, one commit each.

## (a) Delete `StreamError` — `refactor(stream)`

`StreamError` was constructed at 14 sites and matched at zero. Its type information died via `.to_string()` into `PipelineError::Fatal(String)` before ever crossing the `BranchControl` seam; the variant distinction (`MissingElement` vs `FailedOperation`) changed nothing but a Display prefix.

The card said "pick one honestly" — delete it, or make the variants drive `PipelineError` classification at the seam. Re-verification found there is no policy for it to drive:

- **attach** runs under the same state lock as the `input_ready()` check, so a missing tee mid-attach is genuine breakage, not a retryable race;
- the retryable cases (`NotReady`, `Transient`) were already constructed as `PipelineError` directly at the seam;
- five sites live inside `init()`'s GStreamer callbacks, where the error only feeds a log line and never crosses a seam.

Every site's honest classification is Fatal → deletion. Sites now use anyhow `context`/`anyhow!` with the `"Failed to find element: X"` message text kept verbatim, so logs read the same. `stream::errors` is now exactly the `BranchControl` seam language: `PipelineError` alone.

## (b) Single-source the retryable predicate — `refactor(signal)`

The set `{Timeout, NotReady, PipelineBusy}` was spelled character-for-character twice in the `ResponseError` impl — once to map 503, once to attach `Retry-After`. Adding a retryable variant and missing one list meant a 503 with no `Retry-After`, or the reverse.

A private `SignalError::http_contract()` match now returns `(StatusCode, Option<retry-after>)` per variant; `status_code()` and `error_response()` are one-line accessors over it. The match stays exhaustive, so a new variant forces deciding both halves of the contract in a single arm. (Chosen over a bare `is_retryable()` predicate, which would have left `status_code()`'s match with unreachable arms or a drift-prone catch-all.)

## Verification

- `cargo test --all-targets`: **66 lib + 14 integration** green; contract tests in `signal/errors.rs` unchanged, pinning that nothing observable moved
- `cargo clippy --all-targets -- -D warnings`: clean
- Manual `--ignored` e2e (`pipeline_survives_repeated_handshake_failures`): **passed** (18.8s)
- Browser media guard (`tests/browser/run.sh`): **PASS** — frames decoded 0→148 climbing, H264 1280×720

Progress log updated in the proposal doc. No CONTEXT.md change — no new domain term crystallized, and the glossary never referenced `StreamError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV