### PR TITLE
refactor(startup): assemble owns the bus-reap channel via a pipeline factory

### DIFF
--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -130,6 +130,36 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   e2e passed (18.8s), and the browser media guard passed (frames 0→148
   climbing).
 
+- **D6 — landed (2026-07-12, PR #121).** `assemble` now takes a pipeline
+  factory (`impl FnOnce(mpsc::Sender<BranchId>) -> P`) and owns the
+  bus-reap channel; the capacity moved to one `BRANCH_FAILURE_CAPACITY`
+  const in `startup.rs` whose comment records why overflow is safe (the
+  bus handler `try_send`s; the sweep is the backstop). The handle-return
+  tension resolved as the card's second option (approved by Kun):
+  `assemble` returns `(Application, P)` — both test files need the
+  constructed pipeline (`snapshot()`/`fail_branch()`/`ready()`), and the
+  factory-captures-a-clone alternative would have traded three lines of
+  channel ceremony for five of capture ceremony at exactly the sites that
+  need the handle; the one wart is `main.rs` ignoring it with
+  `let (app, _pipeline)`. Re-verification found a **fourth** call site
+  the card missed: `assemble_rejects_a_mismatched_whip_port` built a
+  throwaway `channel(1)` just to satisfy the parameter — the clearest
+  symptom of the channel not belonging in the interface. The port check
+  now runs before the factory, so on bad config the pipeline is never
+  constructed; that test pins the ordering with a
+  `|_| -> TestPipeline { unreachable!(...) }` factory and lost its
+  throwaway channel. `spawn_app`'s `set_ready(true)` moved inside the
+  factory, preserving ready-before-coordinator ordering exactly. The
+  sink-present-from-birth invariant (C3) is now unexpressible to get
+  wrong: the sender exists nowhere outside `assemble`. No new CONTEXT.md
+  term ("pipeline factory" is implementation detail, as with D5).
+  Verified: 66 lib + 14 integration green, clippy `-D warnings` clean,
+  the manual `--ignored` e2e passed (18.6s; one cold-start flake on the
+  fresh worktree's first-ever run, clean on rerun), and the browser
+  media guard passed (frames 0→148 climbing) — run deliberately because
+  it exercises the release binary through `main.rs`, the one call site
+  no test executes.
+
 ---
 
 ## Required reading before touching code

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use srt_whep::stream::{Args, SharablePipeline};
 use srt_whep::telemetry::{get_subscriber, init_subscriber};
 use std::error::Error;
 use std::net::TcpListener;
-use tokio::sync::mpsc;
 
 /// srt-whep: SRT to WHEP (WebRTC) gateway.
 #[derive(Parser, Debug)]
@@ -24,19 +23,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let subscriber = get_subscriber("srt_whep".into(), "debug".into(), std::io::stdout);
     init_subscriber(subscriber);
 
-    // The bus-reap channel: the pipeline holds the sender (from birth), the
-    // coordinator (inside `assemble`) the receiver. Created here so both ends
-    // exist before either is spawned.
-    let (branch_failures_tx, branch_failures_rx) = mpsc::channel(64);
-    let pipeline = SharablePipeline::new(cli.pipeline.clone(), branch_failures_tx);
     let listener = TcpListener::bind(format!("0.0.0.0:{}", cli.pipeline.port))
         .expect("WHEP port is already in use");
-    let app = Application::assemble(
+    let (app, _pipeline) = Application::assemble(
         listener,
-        pipeline,
+        |branch_failures| SharablePipeline::new(cli.pipeline.clone(), branch_failures),
         cli.coordinator.to_config(),
         Some(cli.pipeline.port),
-        branch_failures_rx,
     )?;
 
     // Any termination signal stops everything gracefully: the HTTP server

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -36,6 +36,12 @@ pub fn run(listener: TcpListener, signal: SignalHandle) -> Result<Server, std::i
     Ok(server)
 }
 
+/// Bus-reap channel buffer: how many branch failures can queue while the
+/// coordinator is busy. The pipeline's bus handler `try_send`s and drops the
+/// report when full (the sweep remains a backstop), so overflow degrades to
+/// a slower reap, never a stall.
+const BRANCH_FAILURE_CAPACITY: usize = 64;
+
 /// The assembled application: coordinator + supervisor + HTTP server,
 /// wired in exactly one place — used by `main`, the signaling integration
 /// tests, and the GStreamer e2e test.
@@ -48,22 +54,27 @@ pub struct Application {
 }
 
 impl Application {
+    /// `make_pipeline` receives the bus-reap sender and must build the
+    /// pipeline from it. The sender exists nowhere else, so the only pipeline
+    /// that can be assembled is one that reports branch failures from birth.
+    /// The constructed pipeline is returned alongside the application — tests
+    /// drive their fake through it.
     pub fn assemble<P>(
         listener: TcpListener,
-        pipeline: P,
+        make_pipeline: impl FnOnce(mpsc::Sender<BranchId>) -> P,
         config: CoordinatorConfig,
         expected_whip_port: Option<u16>,
-        branch_failures: mpsc::Receiver<BranchId>,
-    ) -> Result<Self, std::io::Error>
+    ) -> Result<(Self, P), std::io::Error>
     where
         P: BranchControl + PipelineLifecycle + 'static,
     {
         let port = listener.local_addr()?.port();
         // The pipeline's whipclientsink posts loopback WHIP offers to a fixed
         // port; if the HTTP server is bound elsewhere those offers 404 silently.
-        // Fail loudly at wiring time instead. (This coupling exists only for the
-        // loopback WHIP bridge — see src/stream/branch.rs — and is deleted with
-        // the whepserversink migration, ADR 0001.)
+        // Fail loudly at wiring time, before the pipeline is even constructed.
+        // (This coupling exists only for the loopback WHIP bridge — see
+        // src/stream/branch.rs — and is deleted with the whepserversink
+        // migration, ADR 0001.)
         if let Some(expected) = expected_whip_port {
             if expected != port {
                 return Err(std::io::Error::new(
@@ -75,23 +86,30 @@ impl Application {
                 ));
             }
         }
+        // The bus-reap channel: the pipeline holds the sender (from birth —
+        // the factory shape guarantees it), the coordinator the receiver.
+        let (branch_failures_tx, branch_failures_rx) = mpsc::channel(BRANCH_FAILURE_CAPACITY);
+        let pipeline = make_pipeline(branch_failures_tx);
         // The watchdog restart channel: the coordinator holds the sender (it
         // requests a restart on a trip), the supervisor the receiver (it owns
         // the force-quit + rerun). Created here so both ends exist before
-        // either task is spawned — symmetric with the bus-reap channel.
+        // either task is spawned — like the bus-reap channel above.
         let (restart_tx, restart_rx) = mpsc::channel(1);
         let (signal, reset) =
-            spawn_coordinator(pipeline.clone(), config, branch_failures, restart_tx);
+            spawn_coordinator(pipeline.clone(), config, branch_failures_rx, restart_tx);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let supervisor = Supervisor::spawn(pipeline, reset, shutdown_rx, restart_rx);
+        let supervisor = Supervisor::spawn(pipeline.clone(), reset, shutdown_rx, restart_rx);
         let server = run(listener, signal.clone())?;
-        Ok(Self {
-            server,
-            supervisor,
-            signal,
-            shutdown: shutdown_tx,
-            port,
-        })
+        Ok((
+            Self {
+                server,
+                supervisor,
+                signal,
+                shutdown: shutdown_tx,
+                port,
+            },
+            pipeline,
+        ))
     }
 
     pub fn port(&self) -> u16 {

--- a/tests/e2e_gstreamer.rs
+++ b/tests/e2e_gstreamer.rs
@@ -60,8 +60,6 @@ async fn pipeline_survives_repeated_handshake_failures() {
         decode_video: false,
     };
 
-    let (branch_failures_tx, branch_failures_rx) = tokio::sync::mpsc::channel(64);
-    let pipeline = SharablePipeline::new(args.clone(), branch_failures_tx);
     let config = CoordinatorConfig {
         offer_timeout: Duration::from_secs(10),
         answer_timeout: Duration::from_secs(3),
@@ -74,12 +72,11 @@ async fn pipeline_survives_repeated_handshake_failures() {
     let listener =
         TcpListener::bind(format!("127.0.0.1:{}", HTTP_PORT)).expect("e2e HTTP port in use");
     // The production wiring: coordinator + supervisor + HTTP server.
-    let app = Application::assemble(
+    let (app, pipeline) = Application::assemble(
         listener,
-        pipeline.clone(),
+        |branch_failures| SharablePipeline::new(args.clone(), branch_failures),
         config,
         Some(HTTP_PORT),
-        branch_failures_rx,
     )
     .unwrap();
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();

--- a/tests/signaling.rs
+++ b/tests/signaling.rs
@@ -50,17 +50,22 @@ fn expiring_config(watchdog_threshold: u32) -> CoordinatorConfig {
 fn spawn_app(config: CoordinatorConfig) -> (String, TestPipeline) {
     Lazy::force(&TRACING);
     let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
-    // Share the bus-reap channel between the fake and the coordinator, exactly
-    // as production wires the real pipeline — so `fail_branch` reaches the actor
-    // (the reaping integration test depends on this).
-    let (branch_failures_tx, branch_failures_rx) = tokio::sync::mpsc::channel(64);
-    let pipeline = TestPipeline::new(branch_failures_tx);
-    pipeline.set_ready(true);
-    // The production wiring, supervisor included: TestPipeline::run parks
+    // The production wiring, supervisor included: the fake is built from
+    // assemble's own bus-reap sender, so `fail_branch` reaches the actor (the
+    // reaping integration test depends on this). TestPipeline::run parks
     // until end/quit, so the supervisor sits idle unless the watchdog
     // trips — exactly like the real pipeline between restarts.
-    let app = Application::assemble(listener, pipeline.clone(), config, None, branch_failures_rx)
-        .expect("Failed to assemble app");
+    let (app, pipeline) = Application::assemble(
+        listener,
+        |branch_failures| {
+            let pipeline = TestPipeline::new(branch_failures);
+            pipeline.set_ready(true);
+            pipeline
+        },
+        config,
+        None,
+    )
+    .expect("Failed to assemble app");
     let address = format!("http://127.0.0.1:{}", app.port());
     tokio::spawn(app.run_until_stopped(std::future::pending()));
     (address, pipeline)
@@ -514,17 +519,15 @@ async fn assemble_rejects_a_mismatched_whip_port() {
     Lazy::force(&TRACING);
     let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
     let bound = listener.local_addr().unwrap().port();
-    let pipeline = TestPipeline::default();
     // Deliberately claim a different callback port than the one bound.
     let wrong = bound.checked_add(1).unwrap_or(bound - 1);
-    // Assembly fails on the port check before the reap channel is used.
-    let (_fail_tx, fail_rx) = tokio::sync::mpsc::channel(1);
     let result = Application::assemble(
         listener,
-        pipeline,
+        |_branch_failures| -> TestPipeline {
+            unreachable!("assembly fails the port check before constructing the pipeline")
+        },
         functional_config(),
         Some(wrong),
-        fail_rx,
     );
     assert!(result.is_err(), "mismatched whip port must fail assembly");
 }


### PR DESCRIPTION
Round-2 architecture-deepening candidate **D6** (see `docs/proposals/2026-07-11-architecture-deepening-candidates.md`).

## Problem

`Application::assemble` was almost deep — one call wires coordinator + supervisor + HTTP server — except the bus-reap channel: every caller had to create the channel, hand the sender to the pipeline constructor, and hand the receiver to `assemble`. The sink-present-from-birth invariant (C3) was honored by convention at four call sites, not by construction at the seam. The fourth site (`assemble_rejects_a_mismatched_whip_port`) built a throwaway `channel(1)` just to satisfy the parameter — the clearest symptom that the channel didn't belong in the caller's interface.

## Change

- `assemble` takes a pipeline factory (`impl FnOnce(mpsc::Sender<BranchId>) -> P`) and creates the channel internally. The sender exists nowhere outside `assemble`, so the only pipeline that can be assembled is one that reports branch failures from birth — the invariant is now unexpressible to get wrong.
- `assemble` returns `(Application, P)`: both test files need the constructed pipeline handle (`snapshot()`/`fail_branch()`/`ready()`); `main.rs` ignores it.
- Channel capacity lives in one `BRANCH_FAILURE_CAPACITY` const with a comment recording why overflow is safe (the bus handler `try_send`s; the sweep remains a backstop).
- The port check runs before the factory: a mismatched port fails assembly before the pipeline is even constructed. The mismatched-port test pins that ordering with an `unreachable!` factory.
- `spawn_app`'s `set_ready(true)` moved inside the factory, preserving ready-before-coordinator ordering exactly.

## Verification

- `cargo test --all-targets`: 66 lib + 14 integration green; clippy `-D warnings` clean
- Manual `--ignored` e2e `pipeline_survives_repeated_handshake_failures`: passed (18.6s)
- Browser media guard `tests/browser/run.sh`: **PASS** (frames 0→148 climbing, 1280×720 H264) — run deliberately because it exercises the release binary through `main.rs`, the one call site no test executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV