### PR TITLE
refactor(branch): detach tolerates partial attach state; contract lives in branch.rs (D7)

### DIFF
--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -160,6 +160,40 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   it exercises the release binary through `main.rs`, the one call site
   no test executes.
 
+- **D7 — landed (2026-07-12, PR #122), both tiers.** Design review
+  (approved by Kun) took tier 1 + tier 2 together rather than the doc move
+  alone: doc-move-only would have enshrined the wart in `branch.rs`'s own
+  interface docs ("detach aborts at the first unlinked queue; leftovers
+  wait for a restart"), whereas hardening first lets the moved docs state a
+  clean contract — `detach` removes every element this branch put in the
+  pipeline, however far `attach` got. Tier 2:
+  `remove_branch_from_pipeline`'s exists-but-unlinked arm now removes the
+  element directly (no tee pad to release) instead of erroring, so the
+  failed-attach cleanup detach in `gst_pipeline.rs` actually cleans instead
+  of logging "cleanup also failed" and leaning on the next restart. The
+  arm is reachable only from partial state: a normal no-audio branch has
+  no audio queue at all (absent → skip), and `link_many` links
+  sequentially, so a linked sink pad always takes the pad-probe path. Two
+  discoveries beyond the card: (1) ADR 0002 already *asserted* "detach
+  tolerates a half-built branch" — the code only half-delivered it
+  (absent yes, unlinked no); tier 2 aligns the code with the ADR, no ADR
+  edit needed. (2) The card's "done when" imagined a manual e2e as the
+  only tier-2 verification, but `bus.rs`/`egress.rs` already run
+  `gst::init()` unit tests in CI — so the partial-attach teardown is now
+  pinned by an automated test
+  (`detach_after_a_partial_attach_removes_everything_it_can_reach`,
+  core elements only: queue/identity/fakesink stand-ins found by derived
+  name), written red-first against the old abort behaviour. The caller
+  comment at `gst_pipeline.rs` shrank from nine lines of borrowed
+  mechanics to caller-local facts (ADR 0002 location note, error
+  reporting, id-never-mapped). No new CONTEXT.md term — post-hardening,
+  "partial attach" is not even part of the caller-visible contract, which
+  is the point. Verified: 67 lib + 14 integration green, clippy
+  `-D warnings` clean, the manual `--ignored` e2e passed (18.8s, first
+  try), and the browser media guard passed (frames 0→145 climbing).
+  **Round 2 complete: D1–D7 all landed.** Deferred for a future round:
+  the PeerGone 404 honesty fix (wire-visible).
+
 ---
 
 ## Required reading before touching code

--- a/src/stream/branch.rs
+++ b/src/stream/branch.rs
@@ -16,7 +16,7 @@
 //! `startup.rs` imports [`WHIP_SINK_ROUTE`] and the WHIP handler imports
 //! [`whip_sink_path`], so the HTTP contract and the whipclientsink's endpoint
 //! can never drift apart.
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{Context, Error, Result};
 use gst::prelude::*;
 use gstreamer as gst;
 
@@ -73,6 +73,11 @@ impl Branch {
     /// re-encodes it internally. This works around a caps-negotiation bug in
     /// webrtcsink 0.15.x on macOS, where H264 passthrough fails with
     /// not-negotiated on `GstAppSrc:video_0` (see `--decode-video`).
+    ///
+    /// On error, attach does NOT undo its own work: elements it already
+    /// added (whip sink, queues, decoder) stay in the pipeline. Call
+    /// [`Self::detach`] to clean up — it removes everything this branch put
+    /// in the pipeline, however far attach got.
     ///
     /// Synchronous GStreamer calls only; the caller may hold the pipeline
     /// state lock.
@@ -168,7 +173,12 @@ impl Branch {
     }
 
     /// Tear this viewer's branch down: remove the per-media queues via the
-    /// tee pad-probe dance, then remove the whip sink.
+    /// tee pad-probe dance, then the optional decoder and the whip sink.
+    ///
+    /// Tolerant of partial attach state: removes every element this branch
+    /// put in the pipeline, however far [`Self::attach`] got. Elements that
+    /// were never created are skipped; a queue that was added but never
+    /// linked is removed directly (there is no tee pad to release).
     ///
     /// Awaits GStreamer state changes; the caller must NOT hold the
     /// pipeline state lock.
@@ -240,7 +250,8 @@ impl Branch {
     /// * `queue_name` - Name of the queue element to be removed
     ///
     /// To remove a branch from a pipeline, one has to remove the src pad from the tee element
-    /// and remove the queue element from the pipeline.
+    /// and remove the queue element from the pipeline. A queue that exists but
+    /// was never linked (a partial attach) has no tee pad and is removed directly.
     async fn remove_branch_from_pipeline(
         pipeline: &gst::Pipeline,
         queue_name: &str,
@@ -259,7 +270,6 @@ impl Branch {
             .with_context(|| format!("Failed to find element: {}'s sink pad", queue_name))?;
 
         // Remove src pad from tee if queue is linked
-        let name = queue_name.to_string();
         if queue_sink_pad.is_linked() {
             let tee_src_pad = queue_sink_pad
                 .peer()
@@ -286,10 +296,11 @@ impl Branch {
 
             Self::remove_element_from_pipeline(pipeline, &queue).await?;
         } else {
-            return Err(anyhow!(
-                "Queue {} is not linked and can not be removed.",
-                name
-            ));
+            // Added but never linked: a partial attach got this far and no
+            // further. There is no tee pad to release — remove the element
+            // directly so detach cleans everything it can reach.
+            tracing::debug!("{} was never linked; removing directly", queue_name);
+            Self::remove_element_from_pipeline(pipeline, &queue).await?;
         }
 
         Ok(())
@@ -307,5 +318,44 @@ mod tests {
             "http://localhost:8000/whip_sink/abc",
             whip_endpoint(8000, "abc")
         );
+    }
+
+    #[tokio::test]
+    async fn detach_after_a_partial_attach_removes_everything_it_can_reach() {
+        gst::init().unwrap();
+        let pipeline = gst::Pipeline::new();
+        let branch = Branch::for_id("t1");
+        // Simulate an attach that added its elements but died before linking:
+        // detach finds everything by derived name, so stand-in factories are
+        // fine — what matters is that the queue exists and is unlinked.
+        let queue = gst::ElementFactory::make("queue")
+            .name(branch.video_queue_name())
+            .build()
+            .unwrap();
+        let decoder = gst::ElementFactory::make("identity")
+            .name(branch.video_decoder_name())
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .name(branch.whip_sink_name())
+            .build()
+            .unwrap();
+        pipeline.add_many([&queue, &decoder, &sink]).unwrap();
+
+        branch
+            .detach(&pipeline)
+            .await
+            .expect("detach must tolerate partial attach state");
+
+        for name in [
+            branch.video_queue_name(),
+            branch.video_decoder_name(),
+            branch.whip_sink_name(),
+        ] {
+            assert!(
+                pipeline.by_name(&name).is_none(),
+                "{name} must be removed by detach"
+            );
+        }
     }
 }

--- a/src/stream/gst_pipeline.rs
+++ b/src/stream/gst_pipeline.rs
@@ -127,15 +127,12 @@ impl BranchControl for SharablePipeline {
         };
 
         if let Err(attach_err) = attach_result {
-            // Attach ran partway: best-effort detach of our own half-built
-            // branch so the caller never has to reason about stream-plane
-            // cleanup (ADR 0002 -- the semantic is unchanged; only the location
-            // moved here from the coordinator). detach stops at the first queue
-            // that was added but never linked (remove_branch_from_pipeline
-            // errors on an unlinked queue), so a partial attach can leave
-            // elements behind; they are untracked (the id never entered the
-            // connection map) and are cleared on the next pipeline restart. The
-            // original attach error is what we report.
+            // Attach ran partway: detach our own half-built branch so the
+            // caller never has to reason about stream-plane cleanup (ADR 0002
+            // -- the semantic is unchanged; only the location moved here from
+            // the coordinator). detach tolerates partial attach state, so
+            // everything attach added is removed. The original attach error
+            // is what we report; the id never entered the connection map.
             tracing::warn!(
                 "attach for {} failed ({}); detaching half-built branch",
                 id,


### PR DESCRIPTION
Last card of round 2 (architecture-deepening candidate D7, both tiers — design review approved taking hardening + doc move together).

## What

**Hardening (tier 2):** `remove_branch_from_pipeline`'s exists-but-unlinked arm now removes the element directly — there is no tee pad to release — instead of erroring. The arm is reachable only from partial attach state: a normal no-audio branch has no audio queue at all (absent → skip), and `link_many` links sequentially, so a queue with a linked sink pad always takes the pad-probe path. The failed-attach cleanup detach in `gst_pipeline.rs` now actually cleans everything attach added, instead of aborting at the first unlinked queue and leaning on the next pipeline restart to sweep leftovers.

**Contract locality (tier 1):** the partial-attach semantics move from a nine-line caller comment in `gst_pipeline.rs` into `Branch::attach`/`detach`'s own interface docs — and because the hardening lands first, the documented contract is clean: *detach removes every element this branch put in the pipeline, however far attach got.* The caller comment shrinks to caller-local facts.

## Why doc-move-only was rejected

Tier 1 alone would have enshrined the wart in the module's own interface docs ("detach aborts at the first unlinked queue; leftovers wait for a restart"). ADR 0002 already asserted "`detach` tolerates a half-built branch" — the code only half-delivered it (absent elements yes, unlinked ones no). This PR aligns the code with the ADR; no ADR edit needed.

## Test

New CI-run unit test `detach_after_a_partial_attach_removes_everything_it_can_reach`, written red-first against the old abort behaviour. It simulates an attach that died before linking (queue/identity/fakesink stand-ins, found by derived name — core elements only, no whipclientsink needed) and asserts detach removes all of them.

## Verification

- fmt + clippy `-D warnings` clean
- 67 lib + 14 integration tests green (67th is the new test)
- Manual `--ignored` e2e `pipeline_survives_repeated_handshake_failures` passed (18.8s, first try)
- Browser media guard `tests/browser/run.sh` passed — frames decoded 0→145 climbing, 1280×720 H264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV