### PR TITLE
feat(signal): answer in-flight requests with 410 Gone when their connection dies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,10 @@ viewer through a loopback WHIP bridge inside the same process.
   parked waiter is failed, whether the branch teardown gates the death, and
   whether the watchdog is fed. The sweep and reap rows keep their pinned
   semantics; "a reap does not feed the watchdog" is a value in that table,
-  not a comment.
+  not a comment. On the wire, termination answers requests still in flight
+  with **410 Gone** ("it existed; it just ended"); a later request naming
+  the id gets a plain **404** ("never knew it") — the map holds no
+  tombstones.
 - **Reset** — the restart contract between the supervisor and the
   coordinator: after *every* pipeline stop (error, EOS, watchdog restart,
   shutdown) the supervisor resets signaling, and the coordinator fails all

--- a/docs/proposals/2026-07-11-architecture-deepening-candidates.md
+++ b/docs/proposals/2026-07-11-architecture-deepening-candidates.md
@@ -194,6 +194,38 @@ _(append an entry per landed/declined candidate, same discipline as round 1)_
   **Round 2 complete: D1–D7 all landed.** Deferred for a future round:
   the PeerGone 404 honesty fix (wire-visible).
 
+- **PeerGone honesty fix — landed (2026-07-12, PR #123).** The candidate
+  deferred from D1, taken up after round 2 closed. Design review
+  (approved by Kun) widened the scope from "the two PeerGone surviving
+  legs" to the full honesty line, because exploration showed the
+  dishonesty was provable at three sites, not two:
+  `WaiterNotice::Gone` (used by `Deleted` and `Reaped` too) is a
+  dishonest 404 *by construction* — `terminate` only notifies waiters
+  whose entry it just removed, so the connection always existed. New
+  `SignalError::Gone(id)` → **410 Gone** (no Retry-After: a dead session
+  won't come back; the client's move is a fresh POST) at all three
+  sites; the two genuine-404 families (unknown-id lookups,
+  `MissingEntry::Reject`) stay `NotFound`. The resulting wire invariant
+  is statable in one line — **in-flight at the moment of death → 410
+  ("it existed; it just ended"); later by-id lookups → 404 ("never knew
+  it")** — with no tombstones kept, so it cannot conflict with
+  WHIP/WHEP's 404-after-termination convention (subsequent requests
+  still 404). Recorded in CONTEXT.md's Termination entry. DELETE
+  idempotency (`remove.rs` matching `NotFound` → 204) is untouched: it
+  matches only the `Reject` arm. Pinned three ways: the errors.rs
+  contract tests gained the 410/no-Retry-After rows, the two
+  vanished-peer coordinator tests now assert `Gone`, and a NEW
+  wire-level integration test
+  (`in_flight_requests_get_410_when_the_connection_dies`) parks a WHEP
+  POST, DELETEs the connection, and asserts the parked request resolves
+  410 without Retry-After — the first test to pin the parked-waiter
+  notice on the wire. Verified: 67 lib + 15 integration green, clippy
+  `-D warnings` clean, the manual `--ignored` e2e passed (18.7s; the
+  usual fresh-worktree cold-start flake on the first run, clean on
+  rerun — the real whipclientsink receives the 410 on its offer POST in
+  exactly those vanished-viewer rounds), and the browser media guard
+  passed (frames 0→142 climbing).
+
 ---
 
 ## Required reading before touching code

--- a/src/signal/coordinator.rs
+++ b/src/signal/coordinator.rs
@@ -199,7 +199,7 @@ impl ConnectionState {
     /// notice into the concrete error the parked waiter receives.
     fn notify(self, notice: WaiterNotice, id: &ConnectionId) {
         match notice {
-            WaiterNotice::Gone => self.fail_waiter(SignalError::NotFound(id.clone())),
+            WaiterNotice::Gone => self.fail_waiter(SignalError::Gone(id.clone())),
             WaiterNotice::ExpiredLeg => self.expire(),
             WaiterNotice::Unavailable => self.fail_waiter(SignalError::Unavailable),
         }
@@ -281,9 +281,12 @@ enum MissingEntry {
 /// How a parked waiter learns its connection is terminating.
 #[derive(Clone, Copy)]
 enum WaiterNotice {
-    /// The connection no longer exists: `NotFound`. (For `PeerGone` the
-    /// waiter itself vanished, so there is nobody left to notify; the
-    /// surviving leg's reply is the calling handler's to answer.)
+    /// The connection existed and is ending under the waiter: `Gone` → 410.
+    /// Honest by construction — `terminate` only notifies waiters whose
+    /// entry it just removed, so this is never a plain "unknown id" 404.
+    /// (For `PeerGone` the waiter itself vanished, so there is nobody left
+    /// to notify; the surviving leg's reply is the calling handler's to
+    /// answer — with the same `Gone`.)
     Gone,
     /// The handshake deadline passed: the waiter gets its leg's `Timeout`.
     ExpiredLeg,
@@ -494,9 +497,11 @@ impl<P: BranchControl> Coordinator<P> {
             }
             Ok(OfferDelivery::WaiterGone) => {
                 // The WHEP client vanished while waiting (actix dropped its
-                // handler future). Fail this handshake now.
+                // handler future). Fail this handshake now; the surviving
+                // whipsink leg learns the connection existed but died (410),
+                // not that its id was unknown (404).
                 tracing::warn!("WHEP waiter for {} is gone; failing handshake", id);
-                let _ = reply.send(Err(SignalError::NotFound(id.clone())));
+                let _ = reply.send(Err(SignalError::Gone(id.clone())));
                 let _ = self.terminate(id, TerminateReason::PeerGone).await;
             }
             Err(other) => {
@@ -521,9 +526,11 @@ impl<P: BranchControl> Coordinator<P> {
             }
             Ok(AnswerDelivery::WaiterGone) => {
                 // The whipsink's HTTP request died; it can never receive the
-                // answer, so the handshake is failed.
+                // answer, so the handshake is failed. The surviving WHEP
+                // leg's PATCH gets `Gone` (410): its session existed but
+                // died, unlike a PATCH naming an unknown id (404).
                 tracing::warn!("WHIP waiter for {} is gone; failing handshake", id);
-                let _ = reply.send(Err(SignalError::NotFound(id.clone())));
+                let _ = reply.send(Err(SignalError::Gone(id.clone())));
                 let _ = self.terminate(id, TerminateReason::PeerGone).await;
             }
             Err(other) => {
@@ -890,10 +897,10 @@ mod tests {
             tokio::task::yield_now().await;
 
             // The handshake fails now: the whipsink's surviving leg learns
-            // the connection is gone...
+            // the connection existed but is gone (410, not an unknown-id 404)...
             assert!(matches!(
                 handle.offer_received(id.clone(), offer()).await,
-                Err(SignalError::NotFound(_))
+                Err(SignalError::Gone(_))
             ));
             // ...and, once the actor finishes cleanup, the branch is detached.
             tokio::task::yield_now().await;
@@ -926,10 +933,11 @@ mod tests {
         tokio::task::yield_now().await;
 
         // The browser's PATCH finds the whipsink's waiter gone: the
-        // handshake fails, the entry is dropped, the branch is detached.
+        // handshake fails with `Gone` (its session existed but died — 410,
+        // not an unknown-id 404), the entry is dropped, the branch detached.
         assert!(matches!(
             handle.answer_received("a".to_string(), answer()).await,
-            Err(SignalError::NotFound(_))
+            Err(SignalError::Gone(_))
         ));
         tokio::task::yield_now().await; // let the actor finish branch cleanup
         assert_eq!(vec!["a".to_string()], pipeline.snapshot().removed);
@@ -1253,8 +1261,8 @@ mod tests {
             whip_reply: tx,
             deadline: Instant::now(),
         };
-        state.fail_waiter(SignalError::NotFound("a".into()));
-        assert!(matches!(rx.await.unwrap(), Err(SignalError::NotFound(_))));
+        state.fail_waiter(SignalError::Gone("a".into()));
+        assert!(matches!(rx.await.unwrap(), Err(SignalError::Gone(_))));
     }
 
     #[tokio::test]

--- a/src/signal/errors.rs
+++ b/src/signal/errors.rs
@@ -12,8 +12,19 @@ pub enum SignalError {
     // its Display is already "Invalid SDP: …", so this does not double-prefix.
     #[error(transparent)]
     Sdp(#[from] SdpError),
+    /// The id is not in the connection map — the caller named a connection
+    /// this coordinator never knew (or one long dead: the map holds no
+    /// tombstones, so a later lookup honestly cannot tell the difference).
     #[error("Connection {0} not found")]
     NotFound(String),
+    /// The connection existed but ended while this request was in flight —
+    /// the peer vanished mid-handshake, or the connection was deleted or
+    /// reaped under a parked waiter. Distinct from `NotFound` on the wire:
+    /// 404 = never knew this id; 410 = it existed and just died. Only
+    /// in-flight requests can be answered this honestly; once the entry
+    /// leaves the map, subsequent requests get `NotFound`.
+    #[error("Connection {0} is gone")]
+    Gone(String),
     #[error("Connection {0} is in the wrong state for this operation")]
     WrongState(String),
     #[error("Timed out waiting for the {0}")]
@@ -37,6 +48,9 @@ impl SignalError {
         match self {
             SignalError::InvalidSdp(_) | SignalError::Sdp(_) => (StatusCode::BAD_REQUEST, None),
             SignalError::NotFound(_) => (StatusCode::NOT_FOUND, None),
+            // No Retry-After: a dead session will not come back — the
+            // client's move is a fresh POST, not a retry of this request.
+            SignalError::Gone(_) => (StatusCode::GONE, None),
             SignalError::WrongState(_) => (StatusCode::CONFLICT, None),
             SignalError::Timeout(_) | SignalError::NotReady | SignalError::PipelineBusy(_) => {
                 (StatusCode::SERVICE_UNAVAILABLE, Some("3"))
@@ -92,6 +106,10 @@ mod tests {
             SignalError::NotFound("x".into()).status_code()
         );
         assert_eq!(
+            StatusCode::GONE,
+            SignalError::Gone("x".into()).status_code()
+        );
+        assert_eq!(
             StatusCode::CONFLICT,
             SignalError::WrongState("x".into()).status_code()
         );
@@ -122,6 +140,10 @@ mod tests {
         assert_eq!("3", resp.headers().get("Retry-After").unwrap());
 
         let resp = SignalError::NotFound("x".into()).error_response();
+        assert!(resp.headers().get("Retry-After").is_none());
+
+        // A dead session will not come back: no retry hint on 410 either.
+        let resp = SignalError::Gone("x".into()).error_response();
         assert!(resp.headers().get("Retry-After").is_none());
     }
 

--- a/tests/signaling.rs
+++ b/tests/signaling.rs
@@ -235,6 +235,44 @@ async fn unknown_ids_return_404() {
     // DELETE of an unknown id is idempotent (204), covered by delete_is_idempotent.
 }
 
+/// The other half of the 404 contract: 404 means "never knew this id".
+/// A request that is in flight when its connection dies is answered 410
+/// Gone — the connection existed; it ended under the caller.
+#[tokio::test]
+async fn in_flight_requests_get_410_when_the_connection_dies() {
+    let (address, pipeline) = spawn_app(functional_config());
+    let client = http_client();
+
+    // A WHEP client parks awaiting the offer...
+    let whep_task = {
+        let address = address.clone();
+        tokio::spawn(async move {
+            http_client()
+                .post(format!("{}/channel", address))
+                .header("Content-Type", "application/sdp")
+                .send()
+                .await
+                .expect("whep post failed")
+        })
+    };
+    let id = wait_for_added_connection(&pipeline, 0).await;
+
+    // ...and the connection is deleted while it waits.
+    let del = client
+        .delete(format!("{}/channel/{}", address, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::OK, del.status());
+
+    // The parked request learns its connection existed but is gone —
+    // 410, not the unknown-id 404 (and no Retry-After: a dead session
+    // won't come back; the client's move is a fresh POST).
+    let parked = whep_task.await.unwrap();
+    assert_eq!(StatusCode::GONE, parked.status());
+    assert!(parked.headers().get("Retry-After").is_none());
+}
+
 #[tokio::test]
 async fn delete_is_idempotent() {
     let (address, pipeline) = spawn_app(functional_config());


### PR DESCRIPTION
The candidate deferred from D1, taken up after round 2 closed. **Wire-visible change**, scoped in design review.

## What

New `SignalError::Gone(id)` → **410 Gone**, used everywhere a connection that provably existed ends under an in-flight request:

- both **PeerGone surviving legs** — the whipsink's offer POST when the viewer vanished, and the viewer's answer PATCH when the whipsink's request died;
- **`WaiterNotice::Gone`** — parked waiters of `Deleted`/`Reaped` connections. This one was a dishonest 404 *by construction*: `terminate` only notifies waiters whose entry it just removed, so the connection always existed.

No `Retry-After` on 410: a dead session won't come back — the client's move is a fresh POST, not a retry.

## The wire invariant

> **In-flight at the moment of death → 410 ("it existed; it just ended"). Later by-id lookups → 404 ("never knew it").**

No tombstones are kept, so subsequent requests to a dead session URL still get 404 — no conflict with WHIP/WHEP's 404-after-termination convention. Genuine 404s (unknown-id lookups, `MissingEntry::Reject`) are untouched, as is DELETE idempotency (`remove.rs` matches only the `Reject` arm's `NotFound`). Recorded in CONTEXT.md's Termination entry.

## Tests

- errors.rs contract tests gain the 410 / no-Retry-After rows.
- The two vanished-peer coordinator tests now assert `Gone`.
- **New wire-level integration test** `in_flight_requests_get_410_when_the_connection_dies`: parks a WHEP POST, DELETEs the connection, asserts the parked request resolves 410 without Retry-After — the first test to pin the parked-waiter notice on the wire.

## Verification

- fmt + clippy `-D warnings` clean; 67 lib + 15 integration tests green
- Manual `--ignored` e2e passed (18.7s) — meaningful here: the real whipclientsink receives the 410 on its offer POST in exactly the vanished-viewer rounds that test exercises
- Browser media guard passed — frames decoded 0→142 climbing, 1280×720 H264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLNqLX3vg3g3H4RKoDvjV